### PR TITLE
Fix seasonal climatologies

### DIFF
--- a/climaf/functions.py
+++ b/climaf/functions.py
@@ -330,8 +330,7 @@ def clim_average(dat, season):
             selmonths = '4,5,6'
 
         if selmonths:
-            avg = ccdo(scyc, operator='timmean -seltimestep,' + selmonths)
-            # avg = ccdo(scyc,operator='timmean -selmon,'+selmonths)
+            avg = ccdo(scyc, operator='timmean -selmonth,' + selmonths)
         #
         #
         # -- Individual months
@@ -432,8 +431,7 @@ def clim_average_fast(dat, season):
             selmonths = '4,5,6'
 
         if selmonths:
-            avg = ccdo_fast(scyc, operator='timmean -seltimestep,' + selmonths)
-            # avg = ccdo(scyc,operator='timmean -selmon,'+selmonths)
+            avg = ccdo_fast(scyc, operator='timmean -selmonth,' + selmonths)
         #
         #
         # -- Individual months


### PR DESCRIPTION
I was trying to compute the seasonal climatologies by myself and compare it with CLIMAF/CDO and I had different results. I realized that changing the flag -seltimestep to -selmonth works (seltimestep looks like a bug? I don't know, I am not familiar with CDO).

See my notebook on ciclad: /home/mlalande/notebooks/examples/season_clim_example-Copy1.ipynb