### PR TITLE
Fixes on mcdo.py (local files, aladin and nemo_time_fx). Handle unicode periods and crs

### DIFF
--- a/climaf/cache.py
+++ b/climaf/cache.py
@@ -412,6 +412,8 @@ def cdrop(obj, rm=True, force=False):
             crs = "select(" + crs + ")"
     elif type(obj) is str:
         crs = obj
+    elif type(obj) is unicode:
+        crs=obj.encode('ascii')
     else:
         clogger.error("%s is not a CliMAF object" % repr(obj))
         return

--- a/climaf/classes.py
+++ b/climaf/classes.py
@@ -1367,10 +1367,22 @@ class ctree(cobject):
         self.register()
 
     def buildcrs(self, crsrewrite=None, period=None):
-        """ Builds the CRS expression representing applying OPERATOR on OPERANDS with PARAMETERS.
+        """ Builds the CRS expression representing applying OPERATOR on 
+        OPERANDS with PARAMETERS.
         Forces period downtree if provided
         A function for rewriting operand's CRS may be provided
+
+        Special case : if operator is 'select' and sole operand is a dataset and there 
+        is no parameters, then return dataset's crs. This is the way to avoid 
+        repetitive data selection, when a data selection has been explictly cached
         """
+        first_op=self.operands[0]
+        if self.operator=='select' and len(self.operands)==1 and \
+           isinstance(first_op,cdataset) and \
+           len(self.parameters.keys())==0 :
+               return first_op.buildcrs(crsrewrite=crsrewrite, period=period)
+        #
+        # General case
         # Operators are listed in alphabetical order; parameters too
         rep = self.operator + "("
         #

--- a/climaf/driver.py
+++ b/climaf/driver.py
@@ -195,6 +195,11 @@ def ceval(cobject, userflags=None, format="MaskedArray",
         recurse_list.append(cobject.crs)
         clogger.debug("Evaluating dataset operand " + cobject.crs + "having kvp=" + repr(cobject.kvp))
         ds = cobject
+        cache_value=cache.hasExactObject(ds) 
+        if cache_value is not None :
+            clogger.debug("Dataset %s exists in cache" % ds)
+            cdedent()
+            return cache_value
         if ds.isLocal() or ds.isCached():
             clogger.debug("Dataset %s is local or cached " % ds)
             #  if the data is local, then

--- a/climaf/period.py
+++ b/climaf/period.py
@@ -180,6 +180,7 @@ def init_period(dates):
     """
 
     # clogger.debug("analyzing  %s"%dates)
+    dates=dates.encode('ascii')
     if not type(dates) is str:
         raise Climaf_Period_Error("arg is not a string : " + repr(dates))
     if dates == 'fx':

--- a/doc/news.rst
+++ b/doc/news.rst
@@ -8,6 +8,11 @@ Changes, newest first:
 
 - V1.2.13:
 
+  - allow to save on heavy dataset selection : selection can be done once for all 
+    and will now be duly reused if CliMAF is forced to cache its value, simply by using :
+  
+    >>> cfile(ds(...))
+
   - cache structure is changed for saving i-nodes (files) (divide by 10 ...); please run
     script **CLIMAF/scripts/reshape_cache.sh** for reshaping your cache, after you
     definitely moved to this CliMAF version; this is not mandatory, but will actually
@@ -26,6 +31,7 @@ Changes, newest first:
     to restrict its effect, based on the value of some facets, through a
     dictionary of criteria. Example, for a given model which CMIP6 data has
     an error for variable ``evspsbl``   on some data versions :
+
     >>> calias('CMIP6,'evspsbl,scale=_1,conditions={ "model":"CanESM5" , "version": ["20180103", "20190112"] })
 
   - :py:class:`~climaf.classes.cpage` has two additional arguments : `insert` for
@@ -40,16 +46,17 @@ Changes, newest first:
     which comes after in the argument objects list)
 
   - fix for operator `plot`  : it actually uses user-provided max and min for 
-    scaling field s order  of magnitude. Also, `min` and `max` can be set when
-    setting explicit levels through argument `colors`; this is useful when field
-    has very large values, largely beyond limits of explicit levels; but `delta`
-    must then also be set (despite it is not used)
+    scaling field s order  of magnitude. If using argument `colors` , min and max
+    will be derived from extreme values. This is useful when field
+    has very large values, largely beyond limits of explicit levels
 
   - Add function :py:func:`~climaf.classes.cvalid` for declaring a
     list of allowed values for project facets/keywords. This allows to better
     constrain the identification of files for a dataset, as e.g. for CMIP6
     when using wildcard such as grid="g*". It avoids mismatch between patterns
-    for fixed fields and pattenrs for variable fields
+    for fixed fields and pattenrs for variable fields. Example :
+
+     >>> cvalid('grid', ["gr", "gn", "gr1", "gr2"], project="CMIP6")
 
   - Projects CMIP5 and CMIP6 are defined even on systems where there is no known
     root location for that data; so, user can define facet 'root' later on, to match
@@ -229,7 +236,6 @@ Changes, newest first:
 
   - Bug fix on ds() for the access to daily datasets with the CMIP5 project
 
-======= end
 
 - 2017/05/02:
 

--- a/doc/news.rst
+++ b/doc/news.rst
@@ -40,7 +40,10 @@ Changes, newest first:
     which comes after in the argument objects list)
 
   - fix for operator `plot`  : it actually uses user-provided max and min for 
-    scaling field s order  of magnitude
+    scaling field s order  of magnitude. Also, `min` and `max` can be set when
+    setting explicit levels through argument `colors`; this is useful when field
+    has very large values, largely beyond limits of explicit levels; but `delta`
+    must then also be set (despite it is not used)
 
   - Add function :py:func:`~climaf.classes.cvalid` for declaring a
     list of allowed values for project facets/keywords. This allows to better

--- a/scripts/gplot.ncl
+++ b/scripts/gplot.ncl
@@ -903,7 +903,6 @@ begin
       vmin=tofloat(vmin/10^power10)
       vmax=tofloat(vmax/10^power10)
       vdelta=tofloat(vdelta/10^power10)
-
     end if
   else
     power10=floattoint(log10(dim_max(ndtooned(tofloat(fld)))))

--- a/scripts/gplot.ncl
+++ b/scripts/gplot.ncl
@@ -906,6 +906,7 @@ begin
     end if
   else
     power10=floattoint(log10(dim_max(ndtooned(tofloat(fld)))))
+    print(power10)
     if ismissing(power10) then 
       print("Field has only missing values" )
       power10=1

--- a/scripts/mcdo.py
+++ b/scripts/mcdo.py
@@ -171,6 +171,7 @@ def main(input_files, output_file, variable=None, alias=None, region=None, units
     # Create a temporary directory
     tmp = tempfile.mkdtemp(prefix="climaf_mcdo")
     clogger.debug("Create temporary dir %s" % tmp)
+    original_directory=os.getcwd()
     os.chdir(tmp)
 
     # Initialize cdo commands
@@ -253,10 +254,14 @@ def main(input_files, output_file, variable=None, alias=None, region=None, units
         
     files_to_treat_before_merging = list()
     for a_file in input_files:
+        if a_file[0:2] == "./" :
+            a_file = original_directory + a_file[1:]
+        if a_file[0]!="/" :
+            a_file = original_directory + "/" +  a_file
         if os.environ.get("CLIMAF_FIX_NEMO_TIME", False):
-            files_to_treat_before_merging.append(nemo_timefix(a_file))
+            a_file = nemo_timefix(a_file)
         if os.environ.get("CLIMAF_FIX_ALADIN_COORD", False):
-            files_to_treat_before_merging.append(aladin_coordfix(a_file), tmp, filevar)
+            a_file = aladin_coordfix(a_file, tmp, filevar)
         files_to_treat_before_merging.append(a_file)
 
     if len(files_to_treat_before_merging) > 1:


### PR DESCRIPTION
My changes on mcdo.py for aladin and nemo_timefix should be double read.