### PR TITLE
Perfs and scalar cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ examples/romain/
 /lmdz/
 /doc/_static/
 /testing/last.out
+NOTES

--- a/NOTES
+++ b/NOTES
@@ -34,3 +34,18 @@ Posons que la sélection 'de base' de région de CliMAF sert surtout à économi
 
 
 
+\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+Comparaison entre modifs : suppresion_index_cache et economie_sur_CRS
+\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+Ceci sur une carte typique avec 2 période de 20 ans, mais une variabililité sur
+3 périodes de 3 ans, le tout pour deux modèles (CNRM, IPSL)
+
+                                   best          sans_index      eco_CRS     base
+Run à cache vide :                41'28(3)       50'25(3)        44'25(3)   47'30(3)
+2° run, résultat disp en cache     0'47           1'26            0'37       1'50    
+3° run, un modèle en moins         1'20           1'59            1'17       2'36
+
+fig16 (saison hybrides), tous modèles
+cache vide                                       10h03(20)       11h30(3)   10h01'(3)
+2° run, résultat disp en cache                   20'             22'           24'        

--- a/climaf/__init__.py
+++ b/climaf/__init__.py
@@ -112,6 +112,10 @@ if not already_inited and not onrtd:
         exec(compile(open(conf_file).read(), conf_file, "exec"), sys.modules['__main__'].__dict__)
     tim(".climaf")
     #
+    # Load cache scalar values 
+    cache.load_cvalues()
+    tim("cload_values")
+    #
     # Init and load macros
     macroFilename = os.environ.get("CLIMAF_MACROS", "~/.climaf.macros")
     cmacro.read(macroFilename)
@@ -123,8 +127,8 @@ if not already_inited and not onrtd:
     cache.cload()
     tim("cload")
     #
+    atexit.register(cache.sync_cvalues)
     atexit.register(cmacro.write, macroFilename)
-    atexit.register(cache.csync)
     tim("atexit")
     if cache.stamping:
         # Check if exiv2 is installed

--- a/climaf/api.py
+++ b/climaf/api.py
@@ -53,7 +53,9 @@ Main functions are :
 
  - ``cprotect`` : protect the cached file for an object from deletion
 
- - ``craz``     : reset cache
+ - ``craz``     : reset fields cache
+
+ - ``raz_cvalues`` : reset scalar values cache
 
  - ``csync``    : save cache index to disk
 
@@ -87,7 +89,7 @@ from .driver import ceval, cfile, cshow, cMA, cvalue, cimport, cexport, calias, 
 from .dataloc import dataloc
 from .operators import cscript, fixed_fields
 from climaf.operators_derive import derive
-from .cache import craz, csync, cdump, cdrop, clist, cls, crm, cdu, cwc, cprotect
+from .cache import craz, csync, cdump, cdrop, clist, cls, crm, cdu, cwc, cprotect, raz_cvalues
 from env.clogging import clogger, clog, clog_file, logdir
 from env.site_settings import atCNRM, onCiclad, atTGCC, atIDRIS, atIPSL, onSpip
 from .plot.plot_params import plot_params, hovm_params

--- a/climaf/cache.py
+++ b/climaf/cache.py
@@ -1064,11 +1064,22 @@ def load_cvalues() :
 
 def sync_cvalues():
     """
-    Write on disk the in-memory dict of 'cvalue' scalars, in json file cvalues.json
+    Read the on-disk of 'cvalue' scalars, update it with the in-memory one and 
+    write it in json file cvalues.json
     """
+    global cvalues
+
     if handle_cvalues is not False :
-        with open("%s/cvalues.json"%(currentCache),"w") as f :
+        ccache="%s/cvalues.json"%(currentCache)
+        tmp="%s/cvalues_tmp.json"%(currentCache)
+        #
+        with open(ccache,"r") as f :
+            onfile=json.load(f)
+        onfile.update(cvalues)
+        cvalues=onfile
+        with open(tmp,"w") as f :
             json.dump(cvalues,f,separators=(',', ': '),indent=3,ensure_ascii=True)
+        os.rename(tmp,ccache)
 
 def raz_cvalues():
     """

--- a/climaf/classes.py
+++ b/climaf/classes.py
@@ -1290,7 +1290,8 @@ def fds(filename, simulation=None, variable=None, period=None, model=None):
     fperiod = timeLimits(filename)
     if period is None:
         if fperiod is None:
-            raise Climaf_Classes_Error("Must provide a period for file %s " % filename)
+            period="fx"
+            #raise Climaf_Classes_Error("Must provide a period for file %s " % filename)
         else:
             period = repr(fperiod)
     else:

--- a/climaf/driver.py
+++ b/climaf/driver.py
@@ -1292,7 +1292,13 @@ def cvalue(obj, index=0,deep=None):
 
     Does use the file representation of the object
     """
-    return cMA(obj,deep=deep).data.flat[index]
+    rep=None
+    if deep is None :
+        rep=cache.has_cvalue(obj.crs,index)
+    if rep is None :
+        rep=float(cMA(obj,deep=deep).data.flat[index])
+        cache.store_cvalue(obj.crs,index,rep)
+    return rep
 
 
 def cexport(*args, **kwargs):

--- a/climaf/driver.py
+++ b/climaf/driver.py
@@ -314,7 +314,7 @@ def ceval_for_ctree(cobject, userflags=None, format="MaskedArray", deep=None, de
     :param recurse_list:
     :return:
     """
-    recurse_list.append(cobject.buildcrs())
+    recurse_list.append(cobject.crs)
     clogger.debug("Evaluating compound object : " + repr(cobject))
     #################################################################
     if deep is not None:
@@ -417,7 +417,7 @@ def ceval_for_scriptChild(cobject, userflags=None, format="MaskedArray", deep=No
     :param recurse_list:
     :return:
     """
-    recurse_list.append(cobject.buildcrs())
+    recurse_list.append(cobject.crs)
     clogger.debug("Evaluating compound object : " + repr(cobject))
     #################################################################
     if deep is not None:
@@ -502,7 +502,7 @@ def ceval_for_cpage(cobject, userflags=None, format="MaskedArray", deep=None, de
     :param recurse_list:
     :return:
     """
-    recurse_list.append(cobject.buildcrs())
+    recurse_list.append(cobject.crs)
     clogger.debug("Evaluating compound object : " + repr(cobject))
     #################################################################
     if deep is not None:
@@ -545,7 +545,7 @@ def ceval_for_cpage_pdf(cobject, userflags=None, format="MaskedArray", deep=None
     :param recurse_list:
     :return:
     """
-    recurse_list.append(cobject.buildcrs())
+    recurse_list.append(cobject.crs)
     clogger.debug("Evaluating compound object : " + repr(cobject))
     #################################################################
     if deep is not None:
@@ -589,7 +589,7 @@ def ceval_for_cens(cobject, userflags=None, format="MaskedArray", deep=None, der
     :param recurse_list:
     :return:
     """
-    recurse_list.append(cobject.buildcrs())
+    recurse_list.append(cobject.crs)
     clogger.debug("Evaluating compound object : " + repr(cobject))
     #################################################################
     if deep is not None:
@@ -1428,7 +1428,7 @@ def cfilePage(cobj, deep, recurse_list=None):
         args.extend([cobj.insert, "-geometry", "x%d+%d+%d" %
                      (insert_height, (cobj.page_width - cobj.insert_width) / 2, y), "-composite"])
 
-    out_fig = cache.generateUniqueFileName(cobj.buildcrs(), format=cobj.format)
+    out_fig = cache.generateUniqueFileName(cobj.crs, format=cobj.format)
     if cobj.page_trim:
         args.append("-trim")
     if cobj.title != "":
@@ -1517,7 +1517,7 @@ def cfilePage_pdf(cobj, deep, recurse_list=None):
 
     #
     # launch process and registering output in cache
-    out_fig = cache.generateUniqueFileName(cobj.buildcrs(), format='pdf')
+    out_fig = cache.generateUniqueFileName(cobj.crs, format='pdf')
 
     args.extend(["--outfile", out_fig])
 

--- a/climaf/driver.py
+++ b/climaf/driver.py
@@ -212,13 +212,16 @@ def ceval_for_cdataset(cobject, userflags=None, format="MaskedArray", deep=None,
     :return:
     """
     recurse_list.append(cobject.crs)
-    clogger.debug("Evaluating dataset operand " + cobject.crs + "having kvp=" + repr(cobject.kvp))
+    clogger.debug("Evaluating dataset operand " + cobject.crs + " having kvp= " + repr(cobject.kvp))
     ds = cobject
     cache_value = cache.hasExactObject(ds)
     if cache_value is not None:
         clogger.debug("Dataset %s exists in cache" % ds)
         cdedent()
-        return cache_value
+        if format == 'file':
+            return cache_value
+        else:
+            return cread(cache_value, classes.varOf(ds))
     if ds.isLocal() or ds.isCached():
         clogger.debug("Dataset %s is local or cached " % ds)
         #  if the data is local, then
@@ -244,7 +247,7 @@ def ceval_for_cdataset(cobject, userflags=None, format="MaskedArray", deep=None,
                 set_variable(derived_value, ds.variable, format=format)
             cdedent()
             return derived_value
-        elif noselect(userflags, ds, format):
+        elif noselect(userflags, ds, format) and format=="file" :
             # The caller is assumed to be able to select the needed sub-period or variable
             # and to select the variable
             clogger.debug("Delivering file set or sets is OK for the target use")
@@ -1275,7 +1278,7 @@ def cMA(obj, deep=None):
       a Masked Array containing the object's value
 
     """
-    clogger.debug("cMA called with arguments" + str(obj))
+    clogger.debug("cMA called with arguments : " + str(obj))
     return climaf.driver.ceval(obj, format='MaskedArray', deep=deep)
 
 

--- a/climaf/netcdfbasics.py
+++ b/climaf/netcdfbasics.py
@@ -143,7 +143,7 @@ def timeLimits(filename):
     f = ncf(filename)
     if 'time_bnds' in f.variables:
         tim = f.variables['time_bnds']
-        if 'units' in dir(tim):
+        if 'units' in dir(tim) and 'calendar' in dir(tim) :
             start = tim[0, 0]
             end = tim[-1, 1]
             ct = netcdftime.utime(tim.units, calendar=tim.calendar)

--- a/climaf/period.py
+++ b/climaf/period.py
@@ -31,9 +31,15 @@ class cperiod(object):
         if isinstance(start, six.string_types) and start == 'fx':
             self.fx = True
             self.pattern = 'fx'
-        elif not isinstance(start, datetime.datetime) or not isinstance(end, datetime.datetime):
-            raise Climaf_Period_Error("issue with start or end, types=%s, %s" % (type(start), type(end)))
-        else:
+        else :
+            if not isinstance(start, datetime.datetime) or not isinstance(end, datetime.datetime):
+                try :
+                    # Assuming start and end use Netcdf advanced calendars (e.g. noleap or 360-day)
+                    # and trying to carry on anyway with dumb python datetime package
+                    start = start._to_real_datetime()
+                    end   =   end._to_real_datetime()
+                except :
+                    raise Climaf_Period_Error("issue with start or end, %s : %s,\n%s : %s" % (type(start), str(start), type(end), str(end)))
             self.start = start
             self.end = end
             if pattern is None:

--- a/doc/news.rst
+++ b/doc/news.rst
@@ -8,6 +8,19 @@ Changes, newest first:
 
 - running:
 
+  - **Scalar values computed using :py:func:`~climaf.driver.cvalue` are now cached**; users can reset the
+    corresponding in-memory and disk caches (both together) using :py:func:`~climaf.cache.raz_cvalues`.
+    Variable cache.handle_cvalues allows (when set to False) to de-activate this cache.
+
+        - Note : function cvalue now returns a Python float (instead of a numpy.float64)
+
+	- Internals :
+	   - this uses an in-memory dict (cache.cvalues) and a Json file (cvalues.json);
+	   - by default, the dict key is the hashed CRS of cvalue's object argument (with cvalue's index argument as suffix)
+	   - variable cache.handle_cvalues can be set to
+	       - False, for de-activating the cache
+               - 'by_crs', for using the objects CRS has dict key value (but some CRS are very long)
+
   - New operators :doc:`scripts/ccdo2_flip` and `ccdo3_flip` allow CliMAF to keep track of the variable 
     available as output of those CDO operators which use an ancilary field as first
     argument (as e.g. 'ifthen' and 'ifthenelse' ).


### PR DESCRIPTION
@jservon may appreciate the addition of a cache for scalars, which he asked for some years ago. This is a cache only for results of function cvalue(). I became convinced when practising by myself the computation of myriads of indices . See new.rst for details. The increase in performance is quite convincing on some use cases

Also, in the same context (multiple indices base on multi-model analysis), I was impressed by the size of CRS expressions (some Mega bytes), their memory footprint, and by the time taken re-computing it. Digging a bit, there was numerous re-computation of the CRS occurring for each object (each time it was involved in an expression). I fixed that. But I cannot guarantee that macros still work fine