### PR TITLE
New perfs and scalar cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ examples/romain/
 /lmdz/
 /doc/_static/
 /testing/last.out
+NOTES

--- a/NOTES
+++ b/NOTES
@@ -34,3 +34,18 @@ Posons que la sélection 'de base' de région de CliMAF sert surtout à économi
 
 
 
+\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+Comparaison entre modifs : suppresion_index_cache et economie_sur_CRS
+\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+Ceci sur une carte typique avec 2 période de 20 ans, mais une variabililité sur
+3 périodes de 3 ans, le tout pour deux modèles (CNRM, IPSL)
+
+                                   best          sans_index      eco_CRS     base
+Run à cache vide :                41'28(3)       50'25(3)        44'25(3)   47'30(3)
+2° run, résultat disp en cache     0'47           1'26            0'37       1'50    
+3° run, un modèle en moins         1'20           1'59            1'17       2'36
+
+fig16 (saison hybrides), tous modèles
+cache vide                                       10h03(20)       11h30(3)   10h01'(3)
+2° run, résultat disp en cache                   20'             22'           24'        

--- a/climaf/__init__.py
+++ b/climaf/__init__.py
@@ -15,7 +15,6 @@ __all__ = ["cache", "classes", "dataloc", "driver", "netcdfbasics",
            "operators", "period", "standard_operators", "cmacro", "html", "functions", "plot",
            "projects", "derived_variables"]
 
-import env.environment
 
 version = "2.0.0"
 

--- a/climaf/__init__.py
+++ b/climaf/__init__.py
@@ -112,6 +112,10 @@ if not already_inited and not onrtd:
         exec(compile(open(conf_file).read(), conf_file, "exec"), sys.modules['__main__'].__dict__)
     tim(".climaf")
     #
+    # Load cache scalar values 
+    cache.load_cvalues()
+    tim("cload_values")
+    #
     # Init and load macros
     macroFilename = os.environ.get("CLIMAF_MACROS", "~/.climaf.macros")
     cmacro.read(macroFilename)
@@ -123,8 +127,8 @@ if not already_inited and not onrtd:
     cache.cload()
     tim("cload")
     #
+    atexit.register(cache.sync_cvalues)
     atexit.register(cmacro.write, macroFilename)
-    atexit.register(cache.csync)
     tim("atexit")
     if cache.stamping:
         # Check if exiv2 is installed

--- a/climaf/api.py
+++ b/climaf/api.py
@@ -83,20 +83,20 @@ from .projects import *
 # All CliMAF functions we want to provide as top-level functions when this module is loaded as "from ... import *"
 #####################################################################################################################
 #
-from .classes import cdef, cdataset, ds, cproject, cpage, cfreqs, cens, eds, fds, cpage_pdf, varOf, crealms
-from .cmacro import macro
-from .driver import ceval, cfile, cshow, cMA, cvalue, cimport, cexport, calias, efile
-from .dataloc import dataloc
-from .operators import cscript, fixed_fields
+from climaf.classes import cdef, cdataset, ds, cproject, cpage, cfreqs, cens, eds, fds, cpage_pdf, varOf, crealms
+from climaf.cmacro import macro
+from climaf.driver import ceval, cfile, cshow, cMA, cvalue, cimport, cexport, calias, efile
+from climaf.dataloc import dataloc
+from climaf.operators import cscript, fixed_fields
 from climaf.operators_derive import derive
-from .cache import craz, csync, cdump, cdrop, clist, cls, crm, cdu, cwc, cprotect, raz_cvalues
+from climaf.cache import craz, csync, cdump, cdrop, clist, cls, crm, cdu, cwc, cprotect, raz_cvalues
 from env.clogging import clogger, clog, clog_file, logdir
 from env.site_settings import atCNRM, onCiclad, atTGCC, atIDRIS, atIPSL, onSpip
-from .plot.plot_params import plot_params, hovm_params
-from .plot.varlongname import varlongname
-from .derived_variables import *
-from .functions import *
-from .easyCMIP_functions import *
+from climaf.plot.plot_params import plot_params, hovm_params
+from climaf.plot.varlongname import varlongname
+from climaf.derived_variables import *
+from climaf.functions import *
+from climaf.easyCMIP_functions import *
 from env.environment import *
 
 

--- a/climaf/api.py
+++ b/climaf/api.py
@@ -53,7 +53,9 @@ Main functions are :
 
  - ``cprotect`` : protect the cached file for an object from deletion
 
- - ``craz``     : reset cache
+ - ``craz``     : reset fields cache
+
+ - ``raz_cvalues`` : reset scalar values cache
 
  - ``csync``    : save cache index to disk
 
@@ -87,7 +89,7 @@ from .driver import ceval, cfile, cshow, cMA, cvalue, cimport, cexport, calias, 
 from .dataloc import dataloc
 from .operators import cscript, fixed_fields
 from climaf.operators_derive import derive
-from .cache import craz, csync, cdump, cdrop, clist, cls, crm, cdu, cwc, cprotect
+from .cache import craz, csync, cdump, cdrop, clist, cls, crm, cdu, cwc, cprotect, raz_cvalues
 from env.clogging import clogger, clog, clog_file, logdir
 from env.site_settings import atCNRM, onCiclad, atTGCC, atIDRIS, atIPSL, onSpip
 from .plot.plot_params import plot_params, hovm_params

--- a/climaf/cache.py
+++ b/climaf/cache.py
@@ -1073,10 +1073,14 @@ def sync_cvalues():
         ccache="%s/cvalues.json"%(currentCache)
         tmp="%s/cvalues_tmp.json"%(currentCache)
         #
-        with open(ccache,"r") as f :
-            onfile=json.load(f)
-        onfile.update(cvalues)
-        cvalues=onfile
+        try  :
+            # Try to get pre-existing on-disk content
+            with open(ccache,"r") as f :
+                onfile=json.load(f)
+            onfile.update(cvalues)
+            cvalues=onfile
+        except :
+            pass
         with open(tmp,"w") as f :
             json.dump(cvalues,f,separators=(',', ': '),indent=3,ensure_ascii=True)
         os.rename(tmp,ccache)

--- a/climaf/cache.py
+++ b/climaf/cache.py
@@ -30,8 +30,8 @@ from env.clogging import clogger
 
 currentCache = None
 cachedirs = None
-handle_cvalues='by_hash' # Can be False, "by_crs" or anything else. 'by_crs' means key=CRS; else means key=hash
-cvalues={}
+handle_cvalues = 'by_hash'  # Can be False, "by_crs" or anything else. 'by_crs' means key=CRS; else means key=hash
+cvalues = dict()
 #: The length for truncating the hash value of CRS expressions when forming cache filenames
 fileNameLength = 60
 #: Define whether we try to have safe naming of cache objects using adaptative filename length
@@ -44,7 +44,7 @@ crs2filename = dict()
 crs2eval = dict()
 #: The list of crs which file has been dropped since last synchronisation between in-memory index and file index
 #  (or at least since the beginning of the session)
-dropped_crs = []
+dropped_crs = list()
 
 #: A dict containing cache index entries (as listed in index file), which
 # were up to now not interpretable, given the set of defined projects
@@ -1022,38 +1022,40 @@ def rebuild():
     return crs2filename
 
 
-def store_cvalue(crs,index,value):
+def store_cvalue(crs, index, value):
     """
     Stores a scalar, as computed by cvalue, in a scalars cache
     """
-    if handle_cvalues is not False :
-        if handle_cvalues=="by_crs" :
-            key=hashlib.sha224((crs+"%d"%index).encode("utf-8")).hexdigest()
-        else :
-            key=crs+"[%d]"%index
-        cvalues[key]=value
+    if handle_cvalues is not False:
+        if handle_cvalues in ["by_crs", ]:
+            key = hashlib.sha224((crs + "%d" % index).encode("utf-8")).hexdigest()
+        else:
+            key = crs + "[%d]" % index
+        cvalues[key] = value
 
-def has_cvalue(crs,index):
+
+def has_cvalue(crs, index):
     """
     Returns a scalar, as computed by cvalue, from the scalars cache (or None if not cached)
     """
-    if handle_cvalues is not False :
-        if handle_cvalues=="by_crs" :
-            key=hashlib.sha224((crs+"%d"%index).encode("utf-8")).hexdigest()
-        else :
-            key=crs+"[%d]"%index
-        return cvalues.get(key,None)
+    if handle_cvalues is not False:
+        if handle_cvalues in ["by_crs", ]:
+            key = hashlib.sha224((crs + "%d" % index).encode("utf-8")).hexdigest()
+        else:
+            key = crs + "[%d]" % index
+        return cvalues.get(key, None)
 
-def load_cvalues() :
+
+def load_cvalues():
     """
     Load in memory the cache of 'cvalue' scalars, from json file cvalues.json
     """
     global cvalues
-    if handle_cvalues is not False :
-        cache_file="%s/cvalues.json"%(currentCache)
-        if os.path.exists(cache_file) :
-            with open(cache_file,"r") as f :
-                cvalues=json.load(f)
+    if handle_cvalues is not False:
+        cache_file = "%s/cvalues.json" % currentCache
+        if os.path.exists(cache_file):
+            with open(cache_file, "r") as f:
+                cvalues = json.load(f)
 
 
 def sync_cvalues():
@@ -1063,28 +1065,29 @@ def sync_cvalues():
     """
     global cvalues
 
-    if handle_cvalues is not False :
-        ccache="%s/cvalues.json"%(currentCache)
-        tmp="%s/cvalues_tmp.json"%(currentCache)
+    if handle_cvalues is not False:
+        ccache = "%s/cvalues.json" % currentCache
+        tmp = "%s/cvalues_tmp.json" % currentCache
         #
-        try  :
+        try:
             # Try to get pre-existing on-disk content
-            with open(ccache,"r") as f :
-                onfile=json.load(f)
+            with open(ccache, "r") as f:
+                onfile = json.load(f)
             onfile.update(cvalues)
-            cvalues=onfile
-        except :
+            cvalues = onfile
+        except:
             pass
-        with open(tmp,"w") as f :
-            json.dump(cvalues,f,separators=(',', ': '),indent=3,ensure_ascii=True)
-        os.rename(tmp,ccache)
+        with open(tmp, "w") as f:
+            json.dump(cvalues, f, separators=(',', ': '), indent=3, ensure_ascii=True)
+        os.rename(tmp, ccache)
+
 
 def raz_cvalues():
     """
     Clear in-memory and on-disk cache of 'cvalue' scalars
     """
-    if handle_cvalues is not False :
-        cvalues={}
+    if handle_cvalues is not False:
+        cvalues = dict()
         sync_cvalues()
 
 

--- a/climaf/cache.py
+++ b/climaf/cache.py
@@ -445,9 +445,8 @@ def cdrop(obj, rm=True, force=False):
                 dropped_crs.append(crs)
                 try:
                     os.rmdir(path_file)
-                except OSError as ex:
+                except OSError:
                     pass
-                    # clogger.warning(ex)
                 return True
             except:
                 clogger.warning("When trying to remove %s : file does not exist in cache" % crs)
@@ -671,7 +670,6 @@ def list_cache():
     Return the list of files in cache directories, using `find`
 
     """
-    files_in_cache = []
     find_return = ""
     for dir_cache in cachedirs:
         rep = os.path.expanduser(dir_cache)
@@ -758,7 +756,6 @@ def clist(size="", age="", access=0, pattern="", not_pattern="", usage=False, co
     rep = os.path.expanduser(cachedirs[0])
 
     # command for research on size/age/access
-    command = ""
     opt_find = ""
     if size:
         if re.search('[kMG]', size) is None:
@@ -779,8 +776,6 @@ def clist(size="", age="", access=0, pattern="", not_pattern="", usage=False, co
 
         # construction of the new dictionary after research on size/age/access
         new_dict = dict()
-        find_return = ""
-        list_search_files_after_find = []
 
         find_return = os.popen(command).read()
         list_search_files_after_find = find_return.split('\n')
@@ -906,9 +901,10 @@ def clist(size="", age="", access=0, pattern="", not_pattern="", usage=False, co
 
     elif remove is True and len_new_dict != 0:
         print("Removed files:")
-        list_tmp_crs = []
-        list_tmp_crs = list(new_dict) if (var_find or pattern is not "" or not_pattern is not "")\
-            else list(crs2filename)
+        if var_find or pattern is not "" or not_pattern is not "":
+            list_tmp_crs = list(new_dict)
+        else:
+            list_tmp_crs = list(crs2filename)
         for crs in list_tmp_crs:
             cdrop(crs, rm=True)
         return list(map(crewrite, list_tmp_crs))
@@ -1058,11 +1054,11 @@ def load_cvalues() :
         if os.path.exists(cache_file) :
             with open(cache_file,"r") as f :
                 cvalues=json.load(f)
-    
+
 
 def sync_cvalues():
     """
-    Read the on-disk of 'cvalue' scalars, update it with the in-memory one and 
+    Read the on-disk of 'cvalue' scalars, update it with the in-memory one and
     write it in json file cvalues.json
     """
     global cvalues
@@ -1090,5 +1086,5 @@ def raz_cvalues():
     if handle_cvalues is not False :
         cvalues={}
         sync_cvalues()
-    
+
 

--- a/climaf/cache.py
+++ b/climaf/cache.py
@@ -279,8 +279,7 @@ def rename(filename, crs):
     crs2filename """
     newfile = generateUniqueFileName(crs, format="nc")
     if newfile:
-        for c in [f for f in crs2filename if crs2filename[f] == filename or
-                                             crs2filename[f] == alternate_filename(filename)]:
+        for c in [f for f in crs2filename if crs2filename[f] in [filename, alternate_filename(filename)]]:
             crs2filename.pop(c)
         os.rename(filename, newfile)
         register(newfile, crs)
@@ -677,7 +676,8 @@ def list_cache():
     for dir_cache in cachedirs:
         rep = os.path.expanduser(dir_cache)
         find_return += os.popen(
-            "find %s -type f \( -name '*.png' -o -name '*.nc' -o -name '*.pdf' -o -name '*.eps' \) -print" % rep).read()
+            r"find %s -type f \( -name '*.png' -o -name '*.nc' -o -name '*.pdf' -o -name '*.eps' \) -print" % rep
+        ).read()
     files_in_cache = find_return.split('\n')
     files_in_cache.pop(-1)
     return files_in_cache
@@ -773,7 +773,7 @@ def clist(size="", age="", access=0, pattern="", not_pattern="", usage=False, co
     var_find = False
     if size or age or access != 0:
         var_find = True
-        command = "find %s -type f \( -name '*.png' -o -name '*.nc' -o -name '*.pdf' -o -name '*.eps' \) %s -print" % \
+        command = r"find %s -type f \( -name '*.png' -o -name '*.nc' -o -name '*.pdf' -o -name '*.eps' \) %s -print" % \
                   (rep, opt_find)
         clogger.debug("Find command is :" + command)
 

--- a/climaf/cache.py
+++ b/climaf/cache.py
@@ -1064,11 +1064,22 @@ def load_cvalues() :
 
 def sync_cvalues():
     """
-    Write on disk the in-memory dict of 'cvalue' scalars, in json file cvalues.json
+    Read the on-disk of 'cvalue' scalars, update it with the in-memory one and 
+    write it in json file cvalues.json
     """
+    global cvalues
+
     if handle_cvalues is not False :
-        with open("%s/cvalues.json"%(currentCache),"w") as f :
+        ccache="%s/cvalues.json"%(currentCache)
+        tmp="%s/cvalues_tmp.json"%(currentCache)
+        #
+        with open(ccache,"r") as f :
+            onfile=json.load(f)
+        onfile.update(cvalues)
+        cvalues=onfile
+        with open(tmp,"w") as f :
             json.dump(cvalues,f,separators=(',', ': '),indent=3,ensure_ascii=True)
+        os.rename(tmp,ccache)
 
 def raz_cvalues():
     """

--- a/climaf/cache.py
+++ b/climaf/cache.py
@@ -11,9 +11,7 @@ CliMAF cache module : store, retrieve and manage CliMAF objects from their CRS e
 
 from __future__ import print_function, division, unicode_literals, absolute_import
 
-import sys
 import six
-import os
 import os.path
 import re
 import time
@@ -26,8 +24,8 @@ from operator import itemgetter
 from env.environment import *
 from climaf import version
 from climaf.utils import Climaf_Cache_Error
-from .classes import compare_trees, cobject, cdataset, guess_projects, allow_error_on_ds
-from .cmacro import crewrite
+from climaf.classes import compare_trees, cobject, cdataset, guess_projects, allow_error_on_ds, ds
+from climaf.cmacro import crewrite
 from env.clogging import clogger
 
 currentCache = None

--- a/climaf/classes.py
+++ b/climaf/classes.py
@@ -748,8 +748,8 @@ class cdataset(cobject):
                 if isinstance(entry, list) and len(entry) > 1:
                     raise Climaf_Classes_Error("This dataset is ambiguous on attribute %s='%s'; please choose among :"
                                                " %s or use either 'ensure_dataset=False' (with method baseFiles or "
-                                               "listfiles) or 'option=\'choices\' (with method explore). Context is %s" %
-                                               (kw, dic[kw], entry, self.kvp))
+                                               "listfiles) or 'option=\'choices\' (with method explore). "
+                                               "Context is %s" % (kw, dic[kw], entry, self.kvp))
             self.files = files
         else:
             raise Climaf_Classes_Error("Unknown option %s" % option)
@@ -1297,8 +1297,8 @@ def fds(filename, simulation=None, variable=None, period=None, model=None):
     fperiod = timeLimits(filename)
     if period is None:
         if fperiod is None:
-            period="fx"
-            #raise Climaf_Classes_Error("Must provide a period for file %s " % filename)
+            period = "fx"
+            # raise Climaf_Classes_Error("Must provide a period for file %s " % filename)
         else:
             period = repr(fperiod)
     else:
@@ -1407,7 +1407,7 @@ class scriptChild(cobject):
         self.register()
 
     def buildcrs(self, period=None, crsrewrite=None):
-        if period is None :
+        if period is None:
             tmp = self.father.crs
         else:
             tmp = self.father.buildcrs(period=period)
@@ -2058,7 +2058,7 @@ class cpage_pdf(cobject):
     def buildcrs(self, crsrewrite=None, period=None):
         rep = list()
         for line in self.fig_lines:
-            if crsrewrite is not None :
+            if crsrewrite is not None:
                 rep.append("[%s]" % ",".join([f.buildcrs(crsrewrite=crsrewrite) if f is not None else repr(f)
                                               for f in line]))
             else:

--- a/climaf/classes.py
+++ b/climaf/classes.py
@@ -551,7 +551,8 @@ class cdataset(cobject):
 
         Real life example for options ``choices`` and ``ensemble`` ::
 
-          >>> rst=ds(project="CMIP6", model='*', experiment="*ontrol*", realization="r1i1p1f*", table="Amon", variable="rsut", period="1980-1981")
+          >>> rst=ds(project="CMIP6", model='*', experiment="*ontrol*", realization="r1i1p1f*", table="Amon",
+          ...        variable="rsut", period="1980-1981")
           >>> clog('info')
           >>> rst.explore('choices')
           info     : Attribute institute has matching value CNRM-CERFACS
@@ -564,14 +565,18 @@ class cdataset(cobject):
           'realization': ['r1i1p1f2'], 'mip': ['CMIP', 'RFMIP'], 'model': ['CNRM-ESM2-1', 'CNRM-CM6-1']}
 
           >>> # Let us further select by setting experiment=piControl
-          >>> mrst=ds(project="CMIP6", model='*', experiment="piControl", realization="r1i1p1f*", table="Amon", variable="rsut", period="1980-1981")
+          >>> mrst=ds(project="CMIP6", model='*', experiment="piControl", realization="r1i1p1f*", table="Amon",
+          ...         variable="rsut", period="1980-1981")
           >>> mrst.explore('choices')
-          {'institute': ['CNRM-CERFACS'], 'mip': ['CMIP'], 'model': ['CNRM-ESM2-1', 'CNRM-CM6-1'], 'grid': ['gr'], 'realization': ['r1i1p1f2']}
+          {'institute': ['CNRM-CERFACS'], 'mip': ['CMIP'], 'model': ['CNRM-ESM2-1', 'CNRM-CM6-1'], 'grid': ['gr'],
+           'realization': ['r1i1p1f2']}
           >>> small_ensemble=mrst.explore('ensemble')
           >>> small_ensemble
           cens({
-                'CNRM-ESM2-1':ds('CMIP6%%rsut%1980-1981%global%/cnrm/cmip%CNRM-ESM2-1%CNRM-CERFACS%CMIP%Amon%piControl%r1i1p1f2%gr%latest'),
-                'CNRM-CM6-1' :ds('CMIP6%%rsut%1980-1981%global%/cnrm/cmip%CNRM-CM6-1%CNRM-CERFACS%CMIP%Amon%piControl%r1i1p1f2%gr%latest')
+                'CNRM-ESM2-1':ds('CMIP6%%rsut%1980-1981%global%/cnrm/cmip%CNRM-ESM2-1%CNRM-CERFACS%CMIP%Amon%piControl%'
+                                 'r1i1p1f2%gr%latest'),
+                'CNRM-CM6-1' :ds('CMIP6%%rsut%1980-1981%global%/cnrm/cmip%CNRM-CM6-1%CNRM-CERFACS%CMIP%Amon%piControl%'
+                                 'r1i1p1f2%gr%latest')
                })
 
         When option='choices' and period= '*', the period of all matching files will be either :
@@ -598,7 +603,8 @@ class cdataset(cobject):
           >>> so=ds(project="CMIP6", model='CNRM*', experiment="piControl", realization="r1i1p1f2",
           ... table="Omon", variable="so", period="*")
 
-          >>> # What is the overall period covered by the union of all datafiles (but not necessarily by a single model!)
+          >>> # What is the overall period covered by the union of all datafiles
+          >>> # (but not necessarily by a single model!)
           >>> so.explore('choices', operation='union')
           { 'period': [1850-2349], 'model': ['CNRM-ESM2-1', 'CNRM-CM6-1'] .....}
 
@@ -804,16 +810,18 @@ class cdataset(cobject):
         >>> res2=ens.check()
 
         >>> # Define a new project for 'em' data with 3 hours frequency in particular
-        >>> cproject('em_3h','root','group','realm','frequency',separator='|')
+        >>> cproject('em_3h', 'root', 'group', 'realm', 'frequency', separator='|')
         >>> path='/cnrm/cmip/cnrm/simulations/${group}/${realm}/Regu/${frequency}/${simulation}/${variable}_??_YYYY.nc'
         >>> dataloc(project='em_3h', organization='generic', url=path)
 
         >>> # Dataset with 3h frequency for 'tas' variable (instant)
-        >>> tas_3h=ds(project='em_3h',variable='tas',group='AR4',realm='Atmos',frequency='3Hourly', simulation='A1B',period='2050-2100')
+        >>> tas_3h=ds(project='em_3h', variable='tas', group='AR4', realm='Atmos', frequency='3Hourly',
+        ...           simulation='A1B', period='2050-2100')
         >>> res3=tas_3h.check()
 
         >>> # Dataset with 3h frequency for 'pr' variable (time mean)
-        >>> pr_3h=ds(project='em_3h',variable='pr',group='AR4',realm='Atmos',frequency='3Hourly', simulation='A1B',period='2050-2100')
+        >>> pr_3h=ds(project='em_3h', variable='pr', group='AR4', realm='Atmos', frequency='3Hourly', simulation='A1B',
+        ...          period='2050-2100')
         >>> res4=pr_3h.check()
 
         """
@@ -1128,9 +1136,10 @@ class cens(cobject, dict):
     def buildcrs(self, crsrewrite=None, period=None):
         if crsrewrite is None and period is None:
             # A useful optimization, for multi-model studies
-            rep = "cens({%s})" % ",".join(["'%s':%s"% (m, self[m].crs) for m in self.order])
+            rep = "cens({%s})" % ",".join(["'%s':%s" % (m, self[m].crs) for m in self.order])
         else:
-            rep = "cens({%s})" % ",".join(["'%s':%s"% (m, self[m].buildcrs(crsrewrite=crsrewrite, period=period)) for m in self.order])
+            rep = "cens({%s})" % ",".join(["'%s':%s" % (m, self[m].buildcrs(crsrewrite=crsrewrite, period=period))
+                                           for m in self.order])
         return rep
 
     def check(self):
@@ -1222,11 +1231,11 @@ def eds(first=None, **kwargs):
             newcomb = []
             for c in comb:
                 for v in attval[att]:
-                    l = [e for e in c]
-                    l.append((att, v))
-                    newcomb.append(l)
+                    lst = [e for e in c]
+                    lst.append((att, v))
+                    newcomb.append(lst)
             comb = newcomb
-        orderl = []
+        orderl = list()
         for c in comb:
             attval2 = attval.copy()
             label = ""
@@ -1842,7 +1851,7 @@ class cpage(cobject):
                 self.heights = heights
 
                 self.fig_lines = []
-                for l in heights:
+                for height in heights:
                     line = []
                     for c in widths:
                         if len(figs) > 0:
@@ -1879,7 +1888,7 @@ class cpage(cobject):
             nx, ny = 5, 7
         elif n in range(36, 49):
             nx, ny = 6, 8
-        elif n >= 49 :
+        elif n >= 49:
             raise Climaf_Classes_Error("Too many figures in page")
         lines = []
         for i in range(len(figs)):
@@ -1899,7 +1908,7 @@ class cpage(cobject):
         for line in self.fig_lines:
             if crsrewrite is not None:
                 rep.append("[%s]" % ",".join([f.buildcrs(crsrewrite=crsrewrite) if f is not None else repr(f)
-                                           for f in line]))
+                                              for f in line]))
             else:
                 rep.append("[%s]" % ",".join([f.crs if f is not None else repr(f) for f in line]))
             param = "%s,%s, fig_trim='%s', page_trim='%s', format='%s', page_width=%d, page_height=%d" % \
@@ -2046,7 +2055,7 @@ class cpage_pdf(cobject):
             self.heights = heights
 
             self.fig_lines = []
-            for l in heights:
+            for height in heights:
                 line = []
                 for c in widths:
                     if len(figs) > 0:
@@ -2063,7 +2072,7 @@ class cpage_pdf(cobject):
         for line in self.fig_lines:
             if crsrewrite is not None :
                 rep.append("[%s]" % ",".join([f.buildcrs(crsrewrite=crsrewrite) if f is not None else repr(f)
-                                           for f in line]))
+                                              for f in line]))
             else:
                 rep.append("[%s]" % ",".join([f.crs if f is not None else repr(f) for f in line]))
 
@@ -2195,7 +2204,7 @@ def attributeOf(cobject, attrib):
         return attributeOf(list(cobject.values())[0], attrib)
     elif getattr(cobject, attrib, None):
         value = getattr(cobject, attrib)
-        clogger.debug("Find value for object's %s... %s" % (attrib,value))
+        clogger.debug("Find value for object's %s... %s" % (attrib, value))
         return value
     elif isinstance(cobject, ctree):
         clogger.debug("for now, varOf logic is basic (1st operand) - TBD")

--- a/climaf/classes.py
+++ b/climaf/classes.py
@@ -744,8 +744,8 @@ class cdataset(cobject):
                 if isinstance(entry, list) and len(entry) > 1:
                     raise Climaf_Classes_Error("This dataset is ambiguous on attribute %s='%s'; please choose among :"
                                                " %s or use either 'ensure_dataset=False' (with method baseFiles or "
-                                               "listfiles) or 'option=\'choices\' (with method explore)" %
-                                               (kw, dic[kw], entry))
+                                               "listfiles) or 'option=\'choices\' (with method explore). Context is %s" %
+                                               (kw, dic[kw], entry, self.kvp))
             self.files = files
         else:
             raise Climaf_Classes_Error("Unknown option %s" % option)

--- a/climaf/classes.py
+++ b/climaf/classes.py
@@ -16,7 +16,6 @@ import copy
 import os.path
 from functools import reduce, partial
 import six
-from decimal import Decimal
 
 from env.environment import *
 from climaf.utils import Climaf_Classes_Error
@@ -490,10 +489,11 @@ class cdataset(cobject):
         return False
 
     def missingIsOK(self):
-        if alias is None:
+        if self.alias is None:
             return True
-        _, _, _, _, _, missing, _ = self.alias
-        return missing is None
+        else:
+            _, _, _, _, _, missing, _ = self.alias
+            return missing is None
 
     def matches_conditions(self, conditions):
         """
@@ -650,12 +650,12 @@ class cdataset(cobject):
         # else : periods=None
         if periods:
             # print "periods=",periods
-            if option != 'choices':
+            if option not in ['choices', ]:
                 if group_periods_on:
                     raise Climaf_Classes_Error("Can use 'group_periods_on' only with option='choices'")
                 if operation != 'intersection':
                     raise Climaf_Classes_Error("Can use operation %s only with option='choices'" % operation)
-            if operation == 'intersection':
+            if operation in ['intersection', ]:
                 if group_periods_on:
                     # print "periods=",periods
                     merged_periods = [merge_periods(p) for p in list(periods.values())]
@@ -665,7 +665,7 @@ class cdataset(cobject):
                 else:
                     inter = merge_periods(periods[None])
                 wildcards['period'] = inter
-            elif operation == 'union':
+            elif operation in ['union', ]:
                 to_merge = []
                 for plist in list(periods.values()):
                     to_merge.extend(plist)
@@ -680,13 +680,13 @@ class cdataset(cobject):
                 raise Climaf_Classes_Error("Operation %s is not kown " % operation)
         #
         wildcard_attributes_list = [k for k in dic if isinstance(dic[k], six.string_types) and "*" in dic[k]]
-        if option == 'resolve':
+        if option in ['resolve', ]:
             clogger.debug("Trying to resolve on attributes %s" % wildcard_attributes_list)
             for kw in wildcards:
                 val = wildcards[kw]
                 if isinstance(val, list):
                     if len(val) > 1:
-                        if kw == 'period':
+                        if kw in ['period', ]:
                             raise Climaf_Classes_Error("Periods with holes are not handled %s" % val)
                         else:
                             raise Climaf_Classes_Error("Wildcard attribute %s is ambiguous %s" % (kw, val))
@@ -694,7 +694,7 @@ class cdataset(cobject):
                         val = val[0]
                         dic[kw] = val
                 else:
-                    if kw == 'variable':  # Should take care of aliasing to fileVar
+                    if kw in ['variable', ]:  # Should take care of aliasing to fileVar
                         matching_vars = set()
                         paliases = aliases.get(self.project, [])
                         for variable in paliases:
@@ -713,21 +713,20 @@ class cdataset(cobject):
                         dic[kw] = val
             #
             return ds(**dic)
-        elif option == 'choices':
+        elif option in ['choices', ]:
             clogger.debug("Listing possible values for these wildcard attributes %s" % wildcard_attributes_list)
             self.files = files
             return wildcards
-        elif option == 'ensemble':
+        elif option in ['ensemble', ]:
             clogger.debug("Trying to create an ensemble on attributes %s" % wildcard_attributes_list)
             is_ensemble = False
             for kw in wildcards:
                 entry = wildcards[kw]
                 # print "entry=",entry, 'type=',type(entry), 'ensemble_kw=',ensemble_kw
-                if kw == 'period' and isinstance(entry, list):
+                if kw in ['period', ] and isinstance(entry, list):
                     if len(wildcards['period']) > 1:
-                        raise \
-                            Climaf_Classes_Error(
-                                "Cannot create an ensemble with holes in period (%s)" % wildcards['period'])
+                        raise Climaf_Classes_Error("Cannot create an ensemble with holes in period (%s)" %
+                                                   wildcards['period'])
                     entry = entry[0]
                 if isinstance(entry, list):
                     is_ensemble = (len(entry) > 1)
@@ -738,7 +737,7 @@ class cdataset(cobject):
                 clogger.warning("Creating an ensemble with a single member")
             self.files = files
             return eds(first=first, **dic)
-        elif option == 'check_and_store':
+        elif option in ['check_and_store', ]:
             for kw in wildcards:
                 entry = wildcards[kw]
                 if isinstance(entry, list) and len(entry) > 1:
@@ -1056,7 +1055,7 @@ class cens(cobject, dict):
         #
         keylist = list(self)
         try:
-            from natsort import natsorted
+            from natsort.natsort import natsorted
             keylist = natsorted(keylist)
         except:
             keylist.sort()

--- a/climaf/classes.py
+++ b/climaf/classes.py
@@ -1290,7 +1290,8 @@ def fds(filename, simulation=None, variable=None, period=None, model=None):
     fperiod = timeLimits(filename)
     if period is None:
         if fperiod is None:
-            raise Climaf_Classes_Error("Must provide a period for file %s " % filename)
+            period="fx"
+            #raise Climaf_Classes_Error("Must provide a period for file %s " % filename)
         else:
             period = repr(fperiod)
     else:

--- a/climaf/classes.py
+++ b/climaf/classes.py
@@ -644,7 +644,6 @@ class cdataset(cobject):
             if filenameVar:
                 dic["filenameVar"] = filenameVar
         clogger.debug("Looking with dic=%s" % repr(dic))
-        wildcards = None
         # if option != 'check_and_store' :
         wildcards = dict()
         files = selectFiles(return_wildcards=wildcards, merge_periods_on=group_periods_on, **dic)
@@ -1533,7 +1532,6 @@ def ds(*args, **kwargs):
         raise Climaf_Classes_Error("Must provide either only a string or only keyword arguments")
     # clogger.debug("Entering , with args=%s, kwargs=%s"%(`args`,`kwargs`))
     if len(args) == 0:
-        match = None
         if 'period' in kwargs and isinstance(kwargs['period'], six.string_types):
             match = re.match("(?P<option>last|LAST|first|FIRST)_(?P<duration>[0-9]*)(y|Y)$", kwargs['period'])
             if match is not None:
@@ -1691,7 +1689,8 @@ def cmissing(project, missing, *kwargs):
     Such a declaration must follow all ``calias`` declarations for the
     same project
     """
-    pass  # TBD
+    pass
+    # raise NotImplementedError()
 
 
 class cpage(cobject):
@@ -1810,18 +1809,15 @@ class cpage(cobject):
                 "of lists (each representing a line of figures)")
         if isinstance(fig_lines, list):
             if not widths:
-                widths = []
+                widths = list()
                 for line in fig_lines:
                     if len(line) != len(fig_lines[0]):
                         raise Climaf_Classes_Error("each line in fig_lines must have same dimension")
-                for column in fig_lines[0]:
-                    widths.append(round(1. / len(fig_lines[0]), 2))
+                widths.extend([round(1. / len(fig_lines[0]), 2) for column in fig_lines[0]])
             self.widths = widths
 
             if not heights:
-                heights = []
-                for line in fig_lines:
-                    heights.append(round(1. / len(fig_lines), 2))
+                heights = [round(1. / len(fig_lines), 2) for line in fig_lines]
             self.heights = heights
 
             if len(fig_lines) != len(self.heights):
@@ -1842,17 +1838,15 @@ class cpage(cobject):
             else:
                 figs = [fig for fig in fig_lines.order]
                 if not widths:
-                    widths = [1.]
+                    widths = [1., ]
                 self.widths = widths
                 if not heights:
-                    heights = []
-                    for memb in figs:
-                        heights.append(round(1. / len(figs), 2))
+                    heights = [round(1. / len(figs), 2) for mb in figs]
                 self.heights = heights
 
-                self.fig_lines = []
+                self.fig_lines = list()
                 for height in heights:
-                    line = []
+                    line = list()
                     for c in widths:
                         if len(figs) > 0:
                             line.append(fig_lines[figs.pop(0)])
@@ -1897,8 +1891,7 @@ class cpage(cobject):
                 lines.append(line)
             line.append(figs[i])
         j = len(line)
-        for i in range(j, nx):
-            line.append(None)
+        line.extend([None for i in range(j, nx)])
         self.fig_lines = lines
         self.widths = [round(1. / nx, 2) for i in range(nx)]
         self.heights = [round(1. / ny, 2) for i in range(ny)]
@@ -2016,18 +2009,15 @@ class cpage_pdf(cobject):
                 "of lists (each representing a line of figures)")
         if isinstance(fig_lines, list):
             if not widths:
-                widths = []
+                widths = list()
                 for line in fig_lines:
                     if len(line) != len(fig_lines[0]):
                         raise Climaf_Classes_Error("each line in fig_lines must have same dimension")
-                for column in fig_lines[0]:
-                    widths.append(round(1. / len(fig_lines[0]), 2))
+                widths.extend([round(1. / len(fig_lines[0]), 2) for column in fig_lines[0]])
             self.widths = widths
 
             if not heights:
-                heights = []
-                for line in fig_lines:
-                    heights.append(round(1. / len(fig_lines), 2))
+                heights = [round(1. / len(fig_lines), 2) for line in fig_lines]
             self.heights = heights
 
             if len(fig_lines) != len(self.heights):
@@ -2046,17 +2036,15 @@ class cpage_pdf(cobject):
             figs = [fig for fig in fig_lines.order]
 
             if not widths:
-                widths = [1.]
+                widths = [1., ]
             self.widths = widths
             if not heights:
-                heights = []
-                for memb in figs:
-                    heights.append(round(1. / len(figs), 2))
+                heights = [round(1. / len(figs), 2) for memb in figs]
             self.heights = heights
 
-            self.fig_lines = []
+            self.fig_lines = list()
             for height in heights:
-                line = []
+                line = list()
                 for c in widths:
                     if len(figs) > 0:
                         line.append(fig_lines[figs.pop(0)])
@@ -2260,6 +2248,7 @@ def test():
     #
     tos = cdataset(experiment="rcp85", variable="tos", period="19790101-19790102")
     tr = ctree("operator", tos, para1="val1", para2="val2")
+    print(tr)
     # tos.pr()
     #
     # ds1=Dataset(period="1850-2012")

--- a/climaf/classes.py
+++ b/climaf/classes.py
@@ -226,7 +226,7 @@ class cdummy(cobject):
         """
         cdummy class represents dummy arguments in the CRS
         """
-        pass
+        self.crs = self.buildcrs()
 
     def buildcrs(self, period=None, crsrewrite=None):
         return 'ARG'
@@ -1353,7 +1353,7 @@ class ctree(cobject):
         rep = list()
         #
         for op in [o for o in self.operands if o]:
-            if crsrewrite is None and period is None:
+            if crsrewrite is None and period is None and "crs" in dir(op):
                 opcrs = op.crs
             else:
                 opcrs = op.buildcrs(crsrewrite=crsrewrite, period=period)

--- a/climaf/cmacro.py
+++ b/climaf/cmacro.py
@@ -93,8 +93,8 @@ def macro(name, cobj, lobjects=[]):
         return cdummy()
     elif isinstance(cobj, ctree):
         rep = ctree(cobj.operator, cobj.script,
-                    *cobj.operands, **cobj.parameters)
-        rep.operands = list(map(macro, [None for o in rep.operands], rep.operands))
+                    *list(map(macro, [None for o in cobj.operands], cobj.operands)),
+                    **cobj.parameters)
     elif isinstance(cobj, scriptChild):
         rep = scriptChild(macro(None, cobj.father), cobj.varname)
     elif isinstance(cobj, cpage):

--- a/climaf/cmacro.py
+++ b/climaf/cmacro.py
@@ -193,7 +193,7 @@ def cmatch(macro, cobj):
                 argsub += cmatch(mop, op)
         return argsub
     elif isinstance(cobj, scriptChild) and isinstance(macro, scriptChild) and macro.varname == cobj.varname:
-        return cmatch(macro.father, cobj.father, argslist)
+        return cmatch(macro.father, cobj.father)  # , argslist)
     elif isinstance(cobj, cpage) and isinstance(macro, cpage):
         argsub = []
         if cobj.heights == macro.heights and cobj.widths == macro.widths and cobj.orientation == macro.orientation:

--- a/climaf/dataloc.py
+++ b/climaf/dataloc.py
@@ -469,8 +469,8 @@ def selectGenericFiles(urls, return_wildcards=None, merge_periods_on=None, **kwa
     rep = []
     #
     periods = None  # a list of periods available
-    if return_wildcards is not None :
-        periods_dict = return_wildcards.get("period",{})
+    if return_wildcards is not None:
+        periods_dict = return_wildcards.get("period", dict())
         for val in periods_dict:
             periods_dict[val] = set(periods_dict[val])
     else:

--- a/climaf/dataloc.py
+++ b/climaf/dataloc.py
@@ -463,7 +463,13 @@ def selectGenericFiles(urls, return_wildcards=None, merge_periods_on=None, **kwa
     rep = []
     #
     periods = None  # a list of periods available
-    periods_dict = dict()
+    if return_wildcards is not None :
+        periods_dict = return_wildcards.get("period",{})
+        for val in periods_dict:
+            periods_dict[val] = set(periods_dict[val])
+    else:
+        periods_dict = dict()
+        
     #
     period = kwargs['period']
     if period == "*":

--- a/climaf/dataloc.py
+++ b/climaf/dataloc.py
@@ -23,7 +23,7 @@ import netrc
 from functools import partial
 
 from env.environment import *
-from climaf.utils import Climaf_Error, Climaf_Classes_Error
+from climaf.utils import Climaf_Error, Climaf_Classes_Error, Climaf_Data_Error
 from climaf.period import init_period, sort_periods_list
 from climaf.netcdfbasics import fileHasVar
 from env.clogging import clogger
@@ -642,7 +642,7 @@ def selectGenericFiles(urls, return_wildcards=None, merge_periods_on=None, **kwa
                     # print "date_regexp for extracting dates : "+date_regexp0, "file="+f
                     start = re.sub(date_regexp0, r'\1', f)
                     if start == f:
-                        raise Climaf_Data_Error("Start period not found in %s using regexp %s" % (f, regexp0))  # ?
+                        raise Climaf_Data_Error("Start period not found in %s using regexp %s" % (f, date_regexp0))  # ?
                     if hasEnd:
                         end = re.sub(date_regexp0, r'\2', f)
                         fperiod = init_period("%s-%s" % (start, end))
@@ -809,65 +809,65 @@ def ftpmatch(connect, url):
     return lpath_match
 
 
-def glob_remote_data(remote, pattern):
-    """
-    Returns a list of path names that match pattern, for remote data
-    located atremote
-    """
+# def glob_remote_data(remote, pattern):
+#     """
+#     Returns a list of path names that match pattern, for remote data
+#     located atremote
+#     """
+#
+#     if len(remote.split(":")) == 3:
+#         k = 1
+#     else:
+#         k = 0
+#     k = 0
+#
+#     if re.findall("@", remote.split(":")[k]):
+#         username = remote.split(":")[k].split("@")[0]
+#         host = remote.split(":")[k].split("@")[-1]
+#     else:
+#         username = ''
+#         host = remote.split(":")[k]
+#
+#     secrets = netrc.netrc()
+#
+#     if username:
+#         if host in secrets.hosts:
+#             login, account, password = secrets.authenticators(host)
+#             if login != username:
+#                 password = getpass.getpass("Password for host '%s' and user '%s': " % (host, username))
+#         else:
+#             password = getpass.getpass("Password for host '%s' and user '%s': " % (host, username))
+#     else:
+#         if host in secrets.hosts:
+#             username, account, password = secrets.authenticators(host)
+#         else:
+#             username = eval(input("Enter login for host '%s': " % host))
+#             password = getpass.getpass("Password for host '%s' and user '%s': " % (host, username))
+#
+#     try:
+#         connect = ftp.FTP(host, username, password)
+#         listfiles = ftpmatch(connect, pattern)
+#         connect.quit()
+#         return listfiles
+#     except ftp.all_errors as err_ftp:
+#         print(err_ftp)
+#         raise Climaf_Error("Access problem for data %s on host '%s' and user '%s'" % (pattern, host, username))
 
-    if len(remote.split(":")) == 3:
-        k = 1
-    else:
-        k = 0
-    k = 0
 
-    if re.findall("@", remote.split(":")[k]):
-        username = remote.split(":")[k].split("@")[0]
-        host = remote.split(":")[k].split("@")[-1]
-    else:
-        username = ''
-        host = remote.split(":")[k]
-
-    secrets = netrc.netrc()
-
-    if username:
-        if host in secrets.hosts:
-            login, account, password = secrets.authenticators(host)
-            if login != username:
-                password = getpass.getpass("Password for host '%s' and user '%s': " % (host, username))
-        else:
-            password = getpass.getpass("Password for host '%s' and user '%s': " % (host, username))
-    else:
-        if host in secrets.hosts:
-            username, account, password = secrets.authenticators(host)
-        else:
-            username = eval(input("Enter login for host '%s': " % host))
-            password = getpass.getpass("Password for host '%s' and user '%s': " % (host, username))
-
-    try:
-        connect = ftp.FTP(host, username, password)
-        listfiles = ftpmatch(connect, pattern)
-        connect.quit()
-        return listfiles
-    except ftp.all_errors as err_ftp:
-        print(err_ftp)
-        raise Climaf_Error("Access problem for data %s on host '%s' and user '%s'" % (pattern, host, username))
-
-
-def remote_to_local_filename(url):
-    """
-    url: an url of remote data
-
-    Return local filename of remote file
-    """
-    from climaf import remote_cachedir
-
-    if len(url.split(":")) == 3:
-        k = 1
-    else:
-        k = 0
-
-    return rep
+# def remote_to_local_filename(url):
+#     """
+#     url: an url of remote data
+#
+#     Return local filename of remote file
+#     """
+#     from climaf import remote_cachedir
+#
+#     if len(url.split(":")) == 3:
+#         k = 1
+#     else:
+#         k = 0
+#
+#     return rep
 
 
 def glob_remote_data(url, pattern):

--- a/climaf/dataloc.py
+++ b/climaf/dataloc.py
@@ -128,15 +128,18 @@ class dataloc(object):
          - and declaring an exception for one simulation (here, both location and organization are supposed to be
            different)::
 
-            >>> dataloc(project='PRE_CMIP6', model='IPSLCM-Z-HR', simulation='my_exp', organization='EM', url=['~/tmp/my_exp_data'])
+            >>> dataloc(project='PRE_CMIP6', model='IPSLCM-Z-HR', simulation='my_exp', organization='EM',
+            ...         url=['~/tmp/my_exp_data'])
 
          - and declaring a project to access remote data (on multiple servers)::
 
             >>> cproject('MY_REMOTE_DATA', ('frequency', 'monthly'), separator='|')
-            >>> dataloc(project='MY_REMOTE_DATA', organization='generic',url=['beaufix:/home/gmgec/mrgu/vignonl/*/${simulation}SFX${PERIOD}.nc',
-            ... 'ftp:vignonl@hendrix:/home/vignonl/${model}/${variable}_1m_${PERIOD}_${model}.nc']),
+            >>> dataloc(project='MY_REMOTE_DATA', organization='generic',
+            ...         url=['beaufix:/home/gmgec/mrgu/vignonl/*/${simulation}SFX${PERIOD}.nc',
+            ...              'ftp:vignonl@hendrix:/home/vignonl/${model}/${variable}_1m_${PERIOD}_${model}.nc']),
             >>> calias('MY_REMOTE_DATA','tas','tas',filenameVar='2T')
-            >>> tas=ds(project='MY_REMOTE_DATA', simulation='AMIPV6ALB2G', variable='tas', frequency='monthly', period='198101')
+            >>> tas = ds(project='MY_REMOTE_DATA', simulation='AMIPV6ALB2G', variable='tas', frequency='monthly',
+            ...          period='198101')
 
          Please refer to the :ref:`example section <examples>` of the documentation for an example with each
          organization scheme
@@ -274,7 +277,7 @@ def selectFiles(return_wildcards=None, merge_periods_on=None, **kwargs):
     clogger.debug("locs=" + repr(ofu))
     if len(ofu) == 0:
         clogger.warning("no datalocation found for %s %s %s %s  %s %s " % (project, model, simulation, frequency, realm,
-                                                                          table))
+                                                                           table))
     for org, freq, urls in ofu:
         if return_wildcards is not None and len(return_wildcards) > 0 and org != "generic":
             raise Climaf_Error("Can handle multiple facet query only for organization=generic ")
@@ -335,7 +338,9 @@ def selectGenericFiles(urls, return_wildcards=None, merge_periods_on=None, **kwa
 
     Example :
 
-    >>> selectGenericFiles(project='my_projet',model='my_model', simulation='lastexp', variable='tas', period='1980', urls=['~/DATA/${project}/${model}/*${variable}*${PERIOD}*.nc)']
+    >>> selectGenericFiles(project='my_projet',model='my_model', simulation='lastexp', variable='tas', period='1980',
+    ...                    urls=['~/DATA/${project}/${model}/*${variable}*${PERIOD}*.nc)']
+
     /home/stephane/DATA/my_project/my_model/somefilewith_tas_Y1980.nc
 
     In the pattern strings, the keywords that can be used in addition to the argument
@@ -390,7 +395,8 @@ def selectGenericFiles(urls, return_wildcards=None, merge_periods_on=None, **kwa
                     ou que le fichier contient la bonne variable, eventuellement après renommage
                     on retient le fichier
 
-            - A chaque fois qu'on retient un fichier , on ajoute au dict wildcard_facets les valeurs recontrées pour les attributs
+            - A chaque fois qu'on retient un fichier , on ajoute au dict wildcard_facets les valeurs recontrées pour les
+              attributs
 
         - Dès qu'un pattern de la  liste url a eu des fichiers qui collent, on abandonne l'examen des patterns suivants
 

--- a/climaf/derived_variables/__init__.py
+++ b/climaf/derived_variables/__init__.py
@@ -7,7 +7,7 @@ from __future__ import print_function, division, absolute_import  # , unicode_li
 # __all__= [ "atmosphere_derived_variables", "ocean_derived_variables" ]
 __all__ = ["ocean_derived_variables", ]
 
-from env.site_settings import atIPSL, atCerfacs, atCNRM
+from env.site_settings import *
 from env.environment import *
 
 # -- Load only the ipsl derived variables if we are at IPSL

--- a/climaf/driver.py
+++ b/climaf/driver.py
@@ -1292,7 +1292,13 @@ def cvalue(obj, index=0,deep=None):
 
     Does use the file representation of the object
     """
-    return cMA(obj,deep=deep).data.flat[index]
+    rep=None
+    if deep is None :
+        rep=cache.has_cvalue(obj.crs,index)
+    if rep is None :
+        rep=float(cMA(obj,deep=deep).data.flat[index])
+        cache.store_cvalue(obj.crs,index,rep)
+    return rep
 
 
 def cexport(*args, **kwargs):

--- a/climaf/driver.py
+++ b/climaf/driver.py
@@ -314,7 +314,7 @@ def ceval_for_ctree(cobject, userflags=None, format="MaskedArray", deep=None, de
     :param recurse_list:
     :return:
     """
-    recurse_list.append(cobject.buildcrs())
+    recurse_list.append(cobject.crs)
     clogger.debug("Evaluating compound object : " + repr(cobject))
     #################################################################
     if deep is not None:
@@ -417,7 +417,7 @@ def ceval_for_scriptChild(cobject, userflags=None, format="MaskedArray", deep=No
     :param recurse_list:
     :return:
     """
-    recurse_list.append(cobject.buildcrs())
+    recurse_list.append(cobject.crs)
     clogger.debug("Evaluating compound object : " + repr(cobject))
     #################################################################
     if deep is not None:
@@ -502,7 +502,7 @@ def ceval_for_cpage(cobject, userflags=None, format="MaskedArray", deep=None, de
     :param recurse_list:
     :return:
     """
-    recurse_list.append(cobject.buildcrs())
+    recurse_list.append(cobject.crs)
     clogger.debug("Evaluating compound object : " + repr(cobject))
     #################################################################
     if deep is not None:
@@ -545,7 +545,7 @@ def ceval_for_cpage_pdf(cobject, userflags=None, format="MaskedArray", deep=None
     :param recurse_list:
     :return:
     """
-    recurse_list.append(cobject.buildcrs())
+    recurse_list.append(cobject.crs)
     clogger.debug("Evaluating compound object : " + repr(cobject))
     #################################################################
     if deep is not None:
@@ -589,7 +589,7 @@ def ceval_for_cens(cobject, userflags=None, format="MaskedArray", deep=None, der
     :param recurse_list:
     :return:
     """
-    recurse_list.append(cobject.buildcrs())
+    recurse_list.append(cobject.crs)
     clogger.debug("Evaluating compound object : " + repr(cobject))
     #################################################################
     if deep is not None:
@@ -1428,7 +1428,7 @@ def cfilePage(cobj, deep, recurse_list=None):
         args.extend([cobj.insert, "-geometry", "x%d+%d+%d" %
                      (insert_height, (cobj.page_width - cobj.insert_width) / 2, y), "-composite"])
 
-    out_fig = cache.generateUniqueFileName(cobj.buildcrs(), format=cobj.format)
+    out_fig = cache.generateUniqueFileName(cobj.crs, format=cobj.format)
     if cobj.page_trim:
         args.append("-trim")
     if cobj.title != "":
@@ -1517,7 +1517,7 @@ def cfilePage_pdf(cobj, deep, recurse_list=None):
 
     #
     # launch process and registering output in cache
-    out_fig = cache.generateUniqueFileName(cobj.buildcrs(), format='pdf')
+    out_fig = cache.generateUniqueFileName(cobj.crs, format='pdf')
 
     args.extend(["--outfile", out_fig])
 

--- a/climaf/driver.py
+++ b/climaf/driver.py
@@ -237,7 +237,7 @@ def ceval_for_cdataset(cobject, userflags=None, format="MaskedArray", deep=None,
                 set_variable(derived_value, ds.variable, format=format)
             cdedent()
             return derived_value
-        elif noselect(userflags, ds, format) and format=="file" :
+        elif noselect(userflags, ds, format) and format in ["file", ]:
             # The caller is assumed to be able to select the needed sub-period or variable
             # and to select the variable
             clogger.debug("Delivering file set or sets is OK for the target use")

--- a/climaf/driver.py
+++ b/climaf/driver.py
@@ -113,10 +113,10 @@ def capply_script(script_name, *operands, **parameters):
     # Check that all parameters to the call are expected by the script
     command = script.command
     for para in parameters:
-        if not(r"{%s}" % para in command) and not(r"{%s_iso}" % para in command) and para != 'member_label' \
+        if not(r"{%s}" % para in command) and not(r"{%s_iso}" % para in command) and para not in ['member_label', ] \
                 and not para.startswith("add_"):
-                    raise Climaf_Driver_Error("parameter '%s' is not expected by script %s (which command is : %s)" %
-                                              (para, script_name, command))
+            raise Climaf_Driver_Error("parameter '%s' is not expected by script %s (which command is : %s)" %
+                                      (para, script_name, command))
     #
     # Check that only first operand can be an ensemble
     opscopy = list(operands)
@@ -377,9 +377,9 @@ def ceval_for_ctree(cobject, userflags=None, format="MaskedArray", deep=None, de
     #
     #  Only deep=True can propagate downward !
     if deep:
-        down_deep= True
-    else :
-        down_deep= None
+        down_deep = True
+    else:
+        down_deep = None
     #
     # the cache doesn't have a similar tree, let us recursively eval subtrees
     ##########################################################################
@@ -479,10 +479,10 @@ def ceval_for_scriptChild(cobject, userflags=None, format="MaskedArray", deep=No
     clogger.info("nothing relevant found in cache for %s" % cobject.crs)
     #
     #  Only deep=True can propagate downward !
-    if deep :
-        down_deep= True
-    else :
-        down_deep= None
+    if deep:
+        down_deep = True
+    else:
+        down_deep = None
     # Force evaluation of 'father' script
     if ceval_script(cobject.father, down_deep, recurse_list=recurse_list) is not None:
         # Re-evaluate, which should succeed using cache
@@ -525,9 +525,9 @@ def ceval_for_cpage(cobject, userflags=None, format="MaskedArray", deep=None, de
     #
     #  Only deep=True can propagate downward !
     if deep:
-        down_deep= True
-    else :
-        down_deep= None
+        down_deep = True
+    else:
+        down_deep = None
     file = cfilePage(cobject, down_deep, recurse_list=recurse_list)
     cdedent()
     if format == 'file':
@@ -568,9 +568,9 @@ def ceval_for_cpage_pdf(cobject, userflags=None, format="MaskedArray", deep=None
     #
     #  Only deep=True can propagate downward !
     if deep:
-        down_deep= True
-    else :
-        down_deep= None
+        down_deep = True
+    else:
+        down_deep = None
     #
     file = cfilePage_pdf(cobject, down_deep, recurse_list=recurse_list)
     cdedent()
@@ -736,8 +736,8 @@ def ceval_script(scriptCall, deep, recurse_list=[]):
         infile = invalues[0]
         if (scriptCall.operator != 'remote_select') and \
                 not all(map(os.path.exists, infile.split(" "))):
-            raise Climaf_Driver_Error("Internal error : for script %s and 1st operand %s, some input file does not exist among %s:" % \
-                                      (scriptCall.operator,op,infile))
+            raise Climaf_Driver_Error("Internal error : for script %s and 1st operand %s, "
+                                      "some input file does not exist among %s:" % (scriptCall.operator, op, infile))
         subdict[label] = infile
         # if scriptCall.flags.canSelectVar :
         subdict["var"] = classes.varOf(op)
@@ -854,10 +854,10 @@ def ceval_script(scriptCall, deep, recurse_list=[]):
     #
     # Discard selection parameters if selection already occurred for first operand
     # TBD : manage the cases where other operands didn't undergo selection
-    if cache.hasExactObject(scriptCall.operands[0]) :
+    if cache.hasExactObject(scriptCall.operands[0]):
         # for key in ["period","period_iso","var","domain","missing","alias","units"]:
         for key in ["period", "period_iso", "var", "domain", "missing", "alias"]:
-            if key in subdict :
+            if key in subdict:
                 subdict.pop(key)
     #
     # print("subdict="+`subdict`)
@@ -1073,17 +1073,17 @@ def derive_variable(ds):
     if not is_derived_variable(ds.variable, ds.project):
         raise Climaf_Driver_Error("%s is not a derived variable" % ds.variable)
     op, outname, inVarNames, params = derived_variable(ds.variable, ds.project)
-    inVars = []
-    first=True
+    inVars = list()
+    first = True
     for varname in inVarNames:
         dic = copy.deepcopy(ds.kvp)
         dic['variable'] = varname
         # If the dataset has a version attribute, it should be inherited only
         # by the first input variable, an be set to "latest" for the next ones
         # (it would be tricky to do something smarter TBD)
-        if not first and "version" in dic :
+        if not first and "version" in dic:
             dic['version'] = "latest"
-        first=False
+        first = False
         inVars.append(classes.cdataset(**dic))
     params["add_variable"] = ds.variable
     # TODO: force the output variable to be well defined
@@ -1244,7 +1244,7 @@ def cfile(object, target=None, ln=None, hard=None, deep=None):
                         os.link(source, target)
             else:
                 if not os.path.exists(target_dir):
-                            os.makedirs(target_dir)
+                    os.makedirs(target_dir)
                 shutil.copyfile(result, target)
         if not os.path.exists(target):
             raise Climaf_Driver_Error("Issue during the creation of the target file %s" % target)
@@ -1282,7 +1282,7 @@ def cMA(obj, deep=None):
     return climaf.driver.ceval(obj, format='MaskedArray', deep=deep)
 
 
-def cvalue(obj, index=0,deep=None):
+def cvalue(obj, index=0, deep=None):
     """
     Return the value of the array for an object, after MV flattening, at a given index
 
@@ -1295,12 +1295,13 @@ def cvalue(obj, index=0,deep=None):
 
     Does use the file representation of the object
     """
-    rep=None
-    if deep is None :
-        rep=cache.has_cvalue(obj.crs,index)
-    if rep is None :
-        rep=float(cMA(obj,deep=deep).data.flat[index])
-        cache.store_cvalue(obj.crs,index,rep)
+    if deep is None:
+        rep = cache.has_cvalue(obj.crs, index)
+    else:
+        rep = None
+    if rep is None:
+        rep = float(cMA(obj, deep=deep).data.flat[index])
+        cache.store_cvalue(obj.crs, index, rep)
     return rep
 
 
@@ -1338,7 +1339,7 @@ def get_fig_sizes(figfile):
     # On some sites, getoutput first lines have warning messages
     # Furthermore, in case of missing file, last line could be an error -> only consider lines beginning with figfile
     output_figsize = getoutput(" ".join(args_figsize)).split("\n")
-    output_figsize = [l for l in output_figsize if l.startswith(figfile)][-1]
+    output_figsize = [line for line in output_figsize if line.startswith(figfile)][-1]
     # comm_figsize = subprocess.Popen(args_figsize, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     # output_figsize = comm_figsize.stdout.read()
     figsize = str(output_figsize).split(" ").pop(2)

--- a/climaf/driver.py
+++ b/climaf/driver.py
@@ -212,13 +212,16 @@ def ceval_for_cdataset(cobject, userflags=None, format="MaskedArray", deep=None,
     :return:
     """
     recurse_list.append(cobject.crs)
-    clogger.debug("Evaluating dataset operand " + cobject.crs + "having kvp=" + repr(cobject.kvp))
+    clogger.debug("Evaluating dataset operand " + cobject.crs + " having kvp= " + repr(cobject.kvp))
     ds = cobject
     cache_value = cache.hasExactObject(ds)
     if cache_value is not None:
         clogger.debug("Dataset %s exists in cache" % ds)
         cdedent()
-        return cache_value
+        if format == 'file':
+            return cache_value
+        else:
+            return cread(cache_value, classes.varOf(ds))
     if ds.isLocal() or ds.isCached():
         clogger.debug("Dataset %s is local or cached " % ds)
         #  if the data is local, then
@@ -244,7 +247,7 @@ def ceval_for_cdataset(cobject, userflags=None, format="MaskedArray", deep=None,
                 set_variable(derived_value, ds.variable, format=format)
             cdedent()
             return derived_value
-        elif noselect(userflags, ds, format):
+        elif noselect(userflags, ds, format) and format=="file" :
             # The caller is assumed to be able to select the needed sub-period or variable
             # and to select the variable
             clogger.debug("Delivering file set or sets is OK for the target use")
@@ -1275,7 +1278,7 @@ def cMA(obj, deep=None):
       a Masked Array containing the object's value
 
     """
-    clogger.debug("cMA called with arguments" + str(obj))
+    clogger.debug("cMA called with arguments : " + str(obj))
     return climaf.driver.ceval(obj, format='MaskedArray', deep=deep)
 
 

--- a/climaf/driver.py
+++ b/climaf/driver.py
@@ -84,16 +84,6 @@ def capply(climaf_operator, *operands, **parameters):
     return res
 
 
-def capply_operator(climaf_operator, *operands, **parameters):
-    """
-    Create object for application of an internal OPERATOR to OPERANDS with keywords PARAMETERS.
-    TODO: To be implemented
-    """
-    clogger.error("Not yet developped - TBD")
-    raise NotImplementedError("Could not yet apply an operator.")
-    return None
-
-
 def capply_script(script_name, *operands, **parameters):
     """
     Create object for application of a script to OPERANDS with keyword PARAMETERS.
@@ -405,7 +395,15 @@ def ceval_for_ctree(cobject, userflags=None, format="MaskedArray", deep=None, de
         else:
             return obj
     else:
-        raise Climaf_Driver_Error("operator %s is not a script nor known operator %s" % str(cobject.operator))
+        raise Climaf_Driver_Error("operator %s is not a script nor known operator" % str(cobject.operator))
+
+
+def ceval_operator(cobject, deep, *args, **kwargs):
+    raise NotImplementedError()
+
+
+def cstore(cobject, *args, **kwargs):
+    raise NotImplementedError()
 
 
 def ceval_for_scriptChild(cobject, userflags=None, format="MaskedArray", deep=None, derived_list=list(),
@@ -530,7 +528,7 @@ def ceval_for_cpage(cobject, userflags=None, format="MaskedArray", deep=None, de
         down_deep = None
     file = cfilePage(cobject, down_deep, recurse_list=recurse_list)
     cdedent()
-    if format == 'file':
+    if format in ['file', ]:
         return file
     else:
         return cread(file)  # !! Does it make sense ?
@@ -1033,7 +1031,7 @@ def cread(datafile, varname=None, period=None):
         if varname is None:
             raise Climaf_Driver_Error("")
         if period is not None:
-            clogger.warning("Cannot yet select on period (%s) using CMa for files %s - TBD" % (period, files))
+            clogger.warning("Cannot yet select on period (%s) using CMa for files %s - TBD" % (period, datafile))
         from .anynetcdf import ncf
         fileobj = ncf(datafile)
         # Note taken from the CDOpy developper : .data is not backwards

--- a/climaf/functions.py
+++ b/climaf/functions.py
@@ -13,6 +13,7 @@ from six import string_types
 
 import numpy as np
 
+
 def cscalar(dat):
     """ Returns a scalar value using cMA (and not a masked array,
         to avoid the subsetting that is generally needed).
@@ -96,7 +97,7 @@ def fmul(dat1, dat2):
                                       "Members of dat1 =%s ; Members of dat2 =%s\n"
                                       "use ensemble_intersection(dat1,dat2) to get two ensembles "
                                       "with only their common members" % (dat1.order, dat2.order))
-    elif isinstance(dat2, string_types + (int, float, np.float32) ):
+    elif isinstance(dat2, string_types + (int, float, np.float32)):
         c = str(float(dat2))
         return ccdo(dat1, operator='mulc,' + c)
     else:
@@ -564,7 +565,6 @@ def summary(dat):
                 print(m)
                 files = dat[m].baseFiles(ensure_dataset=False)
                 if files:
-                    #for f in str.split(files, ' '):
                     for f in files.split():
                         print(f)
             else:
@@ -583,7 +583,6 @@ def summary(dat):
                           , tmpkvp[key])
                     print('Specify one of them (within ds() or with cdef())')
             if not keytest:
-                #for f in str.split(dat.baseFiles(ensure_dataset=False), ' '):
                 for f in dat.baseFiles(ensure_dataset=False).split():
                     print(f)
         return dat.kvp
@@ -623,7 +622,9 @@ def lonlatvert_interpolation(dat1, dat2=None, vertical_levels=None, cdo_horizont
        >>> zonmean_ref = zonmean(time_average(ref))
 
        >>> dat_interpolated_on_ref = lonlatvert_interpolation(zonmean_dat,zonmean_ref)
-       >>> dat_interpolated_on_list_of_levels = lonlatvert_interpolation(zonmean_dat,vertical_levels='100000,85000,50000,20000,10000,5000,2000,1000')
+       >>> dat_interpolated_on_list_of_levels = lonlatvert_interpolation(zonmean_dat,
+       ...                                                               vertical_levels='100000,85000,50000,20000,'
+       ...                                                                               '10000,5000,2000,1000')
 
     """
 
@@ -736,7 +737,9 @@ def zonmean_interpolation(dat1, dat2=None, vertical_levels=None, cdo_horizontal_
        >>> zonmean_ref = zonmean(time_average(ref))
 
        >>> dat_interpolated_on_ref = zonmean_interpolation(zonmean_dat,zonmean_ref)
-       >>> dat_interpolated_on_list_of_levels = zonmean_interpolation(zonmean_dat,vertical_levels='100000,85000,50000,20000,10000,5000,2000,1000')
+       >>> dat_interpolated_on_list_of_levels = zonmean_interpolation(zonmean_dat,
+       ...                                                            vertical_levels='100000,85000,50000,20000,10000,'
+       ...                                                                            '5000,2000,1000')
 
     """
 
@@ -762,7 +765,8 @@ def diff_zonmean(dat1, dat2):
     Returns the zonal mean bias of dat1 against dat2
 
     The function first computes the zonal means of dat1 and dat2.
-    Then, it interpolates the zonal mean field of dat1 on the zonal mean field of dat2 with the function lonlatvert_interpolation.
+    Then, it interpolates the zonal mean field of dat1 on the zonal mean field of dat2 with the function
+    lonlatvert_interpolation.
     It finally returns the bias field.
 
       >>> ds1= ....   # some dataset, with whatever variable
@@ -826,18 +830,25 @@ def ts_plot(ts, **kwargs):
 
     Examples:
 
-       >>> ds= ....   # some dataset, with whatever variable
-       >>> ts_ds = space_avarege(ds) # Compute the space average
-       >>> p1 = ts_plot(ts_ds) # -- Simply provide the CliMAF object
-       >>> p2 = ts_plot({'my_dataset':ts_ds}) # -- Same as above but specify the name associated with the time series in the plot
+       >>> # some dataset, with whatever variable
+       >>> ds= ....
+       >>> # Compute the space average
+       >>> ts_ds = space_avarege(ds)
+       >>> # -- Simply provide the CliMAF object
+       >>> p1 = ts_plot(ts_ds)
+       >>> # -- Same as above but specify the name associated with the time series in the plot
+       >>> p2 = ts_plot({'my_dataset':ts_ds})
        >>> p3 = ts_plot([ts_ds1,ts_ds2,ts_ds3])
-       >>> p4 = ts_plot([ {'ts_ds1':ts_ds1}, {'ts_ds2':ts_ds2}, {'ts_ds3':ts_ds3} ]) # -- provide multiple time series in a given order with names
-       >>> p5 = ts_plot([ {'ts_ds1':ts_ds1}, {'ts_ds2':ts_ds2}, {'ts_ds3':ts_ds3} ], title='Three Time series', colors=['black','blue','red']) # -- Same as above with lines colors and title
+       >>> # -- provide multiple time series in a given order with names
+       >>> p4 = ts_plot([ {'ts_ds1':ts_ds1}, {'ts_ds2':ts_ds2}, {'ts_ds3':ts_ds3} ])
+       >>> # -- Same as above with lines colors and title
+       >>> p5 = ts_plot([ {'ts_ds1':ts_ds1}, {'ts_ds2':ts_ds2}, {'ts_ds3':ts_ds3} ], title='Three Time series',
+       ...               colors=['black','blue','red'])
 
        >>> ens_ts = cens({'ts_ds1':ts_ds1, 'ts_ds2':ts_ds2, 'ts_ds3':ts_ds3}, order=['ts_ds1','ts_ds2','ts_ds3'])
        >>> ens_ts.set_order(['ts_ds1','ts_ds2','ts_ds3'])
-       >>> p4bis = ts_plot(ens_ts) # -- Same result as p4 above but providing a CliMAF ensemble with specified order
-
+       >>> # -- Same result as p4 above but providing a CliMAF ensemble with specified order
+       >>> p4bis = ts_plot(ens_ts)
 
     """
     # -- If ts is not a CliMAF ensemble, we can't pass it directly to ensemble_ts_plot

--- a/climaf/functions.py
+++ b/climaf/functions.py
@@ -3,6 +3,7 @@
 
 from __future__ import print_function, division, unicode_literals, absolute_import
 
+from climaf.utils import Climaf_Error
 from climaf.api import *
 from climaf.operators import *
 from climaf.driver import cvalue, cfile
@@ -93,10 +94,10 @@ def fmul(dat1, dat2):
                 res_dict[mem] = multiply(dat1[mem], dat2[mem])
             return cens(res_dict, order=dat1.order)
         else:
-            raise climaf.Climaf_Error("Your CliMAF ensembles (dat1 and dat2) do not have the same members "
-                                      "Members of dat1 =%s ; Members of dat2 =%s\n"
-                                      "use ensemble_intersection(dat1,dat2) to get two ensembles "
-                                      "with only their common members" % (dat1.order, dat2.order))
+            raise Climaf_Error("Your CliMAF ensembles (dat1 and dat2) do not have the same members "
+                               "Members of dat1 =%s ; Members of dat2 =%s\n"
+                               "use ensemble_intersection(dat1,dat2) to get two ensembles "
+                               "with only their common members" % (dat1.order, dat2.order))
     elif isinstance(dat2, string_types + (int, float, np.float32)):
         c = str(float(dat2))
         return ccdo(dat1, operator='mulc,' + c)

--- a/climaf/netcdfbasics.py
+++ b/climaf/netcdfbasics.py
@@ -144,7 +144,7 @@ def timeLimits(filename):
     f = ncf(filename)
     if 'time_bnds' in f.variables:
         tim = f.variables['time_bnds']
-        if 'units' in dir(tim):
+        if 'units' in dir(tim) and 'calendar' in dir(tim) :
             start = tim[0, 0]
             end = tim[-1, 1]
             ct = netcdftime.utime(tim.units, calendar=tim.calendar)

--- a/climaf/netcdfbasics.py
+++ b/climaf/netcdfbasics.py
@@ -143,7 +143,7 @@ def timeLimits(filename):
     f = ncf(filename)
     if 'time_bnds' in f.variables:
         tim = f.variables['time_bnds']
-        if 'units' in dir(tim) and 'calendar' in dir(tim) :
+        if 'units' in dir(tim) and 'calendar' in dir(tim):
             start = tim[0, 0]
             end = tim[-1, 1]
             ct = netcdftime.utime(tim.units, calendar=tim.calendar)

--- a/climaf/netcdfbasics.py
+++ b/climaf/netcdfbasics.py
@@ -54,9 +54,8 @@ def varsOfFile(filename):
             lvars.append(filevar)
     # case of scalar coordinates
     if isinstance(vars, dict):
-        for var in vars.keys()  :
-            if var in lvars and \
-               (hasattr(vars[var],"axis") or hasattr(vars[var],"bounds")):
+        for var in vars.keys():
+            if var in lvars and (hasattr(vars[var], "axis") or hasattr(vars[var], "bounds")):
                 lvars.remove(var)
 
     fileobj.close()

--- a/climaf/period.py
+++ b/climaf/period.py
@@ -39,7 +39,8 @@ class cperiod(object):
                     start = start._to_real_datetime()
                     end = end._to_real_datetime()
                 except:
-                    raise Climaf_Period_Error("issue with start or end, %s : %s,\n%s : %s" % (type(start), str(start), type(end), str(end)))
+                    raise Climaf_Period_Error("issue with start or end, %s : %s,\n%s : %s" %
+                                              (type(start), str(start), type(end), str(end)))
             self.start = start
             self.end = end
             if pattern is None:
@@ -344,17 +345,17 @@ def merge_periods(remain_to_merge, already_merged=list(), handle_360_days_year=T
     For dealing with very long list of periods, which do not allow for recursion, we
     proceed with batches of N elements
     """
-    N=300
+    N = 300
     if isinstance(already_merged, list) and len(already_merged) == 0:
         if len(remain_to_merge) < 2:
             return remain_to_merge
-        sorted_remain=sorted(remain_to_merge, key=(lambda x : x.start))
-        if len(sorted_remain) <= N :
+        sorted_remain = sorted(remain_to_merge, key=(lambda x: x.start))
+        if len(sorted_remain) <= N:
             return merge_periods(sorted_remain[1:], [sorted_remain[0]], handle_360_days_year)
         else:
             # Avoid too much recursion
-            first_batch=merge_periods(sorted_remain[0:N])
-            return merge_periods(sorted_remain[N:], first_batch,handle_360_days_year)
+            first_batch = merge_periods(sorted_remain[0:N])
+            return merge_periods(sorted_remain[N:], first_batch, handle_360_days_year)
 
     if len(remain_to_merge) > 0:
         last = already_merged[-1]

--- a/climaf/period.py
+++ b/climaf/period.py
@@ -31,14 +31,14 @@ class cperiod(object):
         if isinstance(start, six.string_types) and start == 'fx':
             self.fx = True
             self.pattern = 'fx'
-        else :
+        else:
             if not isinstance(start, datetime.datetime) or not isinstance(end, datetime.datetime):
-                try :
+                try:
                     # Assuming start and end use Netcdf advanced calendars (e.g. noleap or 360-day)
                     # and trying to carry on anyway with dumb python datetime package
                     start = start._to_real_datetime()
-                    end   =   end._to_real_datetime()
-                except :
+                    end = end._to_real_datetime()
+                except:
                     raise Climaf_Period_Error("issue with start or end, %s : %s,\n%s : %s" % (type(start), str(start), type(end), str(end)))
             self.start = start
             self.end = end
@@ -329,7 +329,8 @@ def sort_periods_list(periods_list):
         insert(clist.pop(), sorted_tree)
     return walk(sorted_tree)
 
-def merge_periods(remain_to_merge, already_merged=[],handle_360_days_year=True):
+
+def merge_periods(remain_to_merge, already_merged=list(), handle_360_days_year=True):
     """
     Provided with a list of periods (even un-sorted), returns a list of periods 
     where all consecutive periods have been merged.
@@ -338,24 +339,23 @@ def merge_periods(remain_to_merge, already_merged=[],handle_360_days_year=True):
     usually be provided
 
     Argument 'handle_360_days_year' allows to merge consecutive periods which miss 
-    only a 31st december,such as in the case with 360-days calendars. It defaults to True 
+    only a 31st december,such as in the case with 360-days calendars. It defaults to True
 
-    For dealing with very long list of periods, which do not allow for recursion, we 
+    For dealing with very long list of periods, which do not allow for recursion, we
     proceed with batches of N elements
     """
     N=300
-    if already_merged == []:
+    if isinstance(already_merged, list) and len(already_merged) == 0:
         if len(remain_to_merge) < 2:
             return remain_to_merge
-        sorted_remain=sorted(remain_to_merge,key=(lambda x : x.start))
-        #sorted = sort_periods_list(remain_to_merge)
+        sorted_remain=sorted(remain_to_merge, key=(lambda x : x.start))
         if len(sorted_remain) <= N :
-            return merge_periods(sorted_remain[1:], [sorted_remain[0]],handle_360_days_year)
+            return merge_periods(sorted_remain[1:], [sorted_remain[0]], handle_360_days_year)
         else:
             # Avoid too much recursion
             first_batch=merge_periods(sorted_remain[0:N])
             return merge_periods(sorted_remain[N:], first_batch,handle_360_days_year)
-        
+
     if len(remain_to_merge) > 0:
         last = already_merged[-1]
         next_one = remain_to_merge.pop(0)
@@ -363,10 +363,10 @@ def merge_periods(remain_to_merge, already_merged=[],handle_360_days_year=True):
         # if (last.end == next_one.start) :
         #    already_merged[-1]=cperiod(last.start,next_one.end)
         if next_one.start <= last.end or \
-           (handle_360_days_year and \
-            last.end.month==12 and last.end.day==31 and \
-            next_one.start.month==1 and next_one.start.day==1 and \
-            next_one.start.year==last.end.year+1) :
+           (handle_360_days_year and
+            last.end.month == 12 and last.end.day == 31 and
+            next_one.start.month == 1 and next_one.start.day == 1 and
+            next_one.start.year == last.end.year + 1):
             if next_one.end > last.end:
                 # the next period is not entirely included in the
                 # last merged one
@@ -376,7 +376,7 @@ def merge_periods(remain_to_merge, already_merged=[],handle_360_days_year=True):
             already_merged.append(next_one)
     #
     if len(remain_to_merge) > 0:
-        return merge_periods(remain_to_merge, already_merged,handle_360_days_year)
+        return merge_periods(remain_to_merge, already_merged, handle_360_days_year)
     else:
         return already_merged
 

--- a/climaf/period.py
+++ b/climaf/period.py
@@ -31,9 +31,15 @@ class cperiod(object):
         if isinstance(start, six.string_types) and start == 'fx':
             self.fx = True
             self.pattern = 'fx'
-        elif not isinstance(start, datetime.datetime) or not isinstance(end, datetime.datetime):
-            raise Climaf_Period_Error("issue with start or end, types=%s, %s" % (type(start), type(end)))
-        else:
+        else :
+            if not isinstance(start, datetime.datetime) or not isinstance(end, datetime.datetime):
+                try :
+                    # Assuming start and end use Netcdf advanced calendars (e.g. noleap or 360-day)
+                    # and trying to carry on anyway with dumb python datetime package
+                    start = start._to_real_datetime()
+                    end   =   end._to_real_datetime()
+                except :
+                    raise Climaf_Period_Error("issue with start or end, %s : %s,\n%s : %s" % (type(start), str(start), type(end), str(end)))
             self.start = start
             self.end = end
             if pattern is None:

--- a/climaf/period.py
+++ b/climaf/period.py
@@ -362,11 +362,9 @@ def merge_periods(remain_to_merge, already_merged=list(), handle_360_days_year=T
         # print "last.end=",last.end,"next.start=",next_one.start
         # if (last.end == next_one.start) :
         #    already_merged[-1]=cperiod(last.start,next_one.end)
-        if next_one.start <= last.end or \
-           (handle_360_days_year and
-            last.end.month == 12 and last.end.day == 31 and
-            next_one.start.month == 1 and next_one.start.day == 1 and
-            next_one.start.year == last.end.year + 1):
+        if next_one.start <= last.end or (handle_360_days_year and last.end.month == 12 and last.end.day == 31 and
+                                          next_one.start.month == 1 and next_one.start.day == 1
+                                          and next_one.start.year == last.end.year + 1):
             if next_one.end > last.end:
                 # the next period is not entirely included in the
                 # last merged one

--- a/climaf/projects/__init__.py
+++ b/climaf/projects/__init__.py
@@ -18,16 +18,18 @@ accumulation. In that case, the conversion to rates assumes a fixed
 month length of 30.3 days (for ensuring minimal bias at year scale)
 
 For listing the declared projects and their specifics, if you are under
-the Python prompt, type e.g. ::
+the Python prompt, type e.g. :
 
+  >>> import climaf
   >>> dir(climaf.projects)
   >>> help(climaf.projects.cmip5)
 
-For knowing the specifics of variables for a given project (as e.g. re-scaling), type ::
+For knowing the specifics of variables for a given project (as e.g. re-scaling), type :
 
+  >>> from climaf.api import *
   >>> aliases["erai"]
 
-and interpret a result such as::
+and interpret a result such as:
 
   'erai': {'clt': ('tcc', 1.0, 0.0, None, 'TCC', None),
            'das': ('d2m', 1.0, 0.0, None, '2D', None),

--- a/climaf/projects/ceres.py
+++ b/climaf/projects/ceres.py
@@ -12,7 +12,7 @@ complain to climaf at cnrm dot fr if this does not fit the needs
 
 Example of a 'ceres' project dataset declaration ::
 
- >>> d=ds('project='ceres, variable='rlds',period='198001',domain=[40.,60.,-10.,+20.])
+ >>> d = ds(project='ceres', variable='rlds', period='198001', domain=[40.,60.,-10.,+20.])
 
 """
 

--- a/climaf/projects/cmip3.py
+++ b/climaf/projects/cmip3.py
@@ -9,10 +9,10 @@ No unit conversion nor variable is renaming performed, yet
 
 Example for a CMIP3 dataset declaration ::
 
- >>> ps=ds(project='CMIP3', model='ncar_ccsm3', experiment='sresa1b', variable='ps', realm='atm', realization='run1', period='*')
-
->>> d=ds(project="CMIP3",variable="*",model="*")
->>> d.explore('choices')
+ >>> ps = ds(project='CMIP3', model='ncar_ccsm3', experiment='sresa1b', variable='ps', realm='atm', realization='run1',
+ ...         period='*')
+ >>> d = ds(project="CMIP3",variable="*",model="*")
+ >>> d.explore('choices')
 
 """
 

--- a/climaf/projects/cmip5.py
+++ b/climaf/projects/cmip5.py
@@ -11,7 +11,8 @@ Syntax for these attributes is described in `the CMIP5 DRS document
 
 Example for a CMIP5 dataset declaration ::
 
- >>> tas1pc=ds(project='CMIP5', model='CNRM-CM6-1', experiment='1pctCO2', variable='tas', table='Amon', realization='r3i1p1f2', period='1860-1861')
+ >>> tas1pc=ds(project='CMIP5', model='CNRM-CM6-1', experiment='1pctCO2', variable='tas', table='Amon',
+ ...           realization='r3i1p1f2', period='1860-1861')
 
 
 

--- a/climaf/projects/cmip6.py
+++ b/climaf/projects/cmip6.py
@@ -10,7 +10,8 @@ Syntax for these attributes is described in `the CMIP6 DRS document <https://goo
 
 Example for a CMIP6 dataset declaration ::
 
- >>> tas1pc=ds(project='CMIP6', model='CNRM-CM6-1', experiment='1pctCO2', variable='tas', table='Amon', realization='r3i1p1f2', period='1860-1861')
+ >>> tas1pc=ds(project='CMIP6', model='CNRM-CM6-1', experiment='1pctCO2', variable='tas', table='Amon',
+ ...           realization='r3i1p1f2', period='1860-1861')
 
 
 
@@ -82,7 +83,7 @@ if True:
     cdef('extent_experiment', 'ssp585', project='CMIP6_extent')
     #
     # -- IPSL-CM6 special historical-EXT experiment
-    project='IPSL-CM6_historical-EXT'
+    project = 'IPSL-CM6_historical-EXT'
     cdef('root',        root,                       project=project)
     cdef('institute',   'IPSL',                     project=project)
     cdef('model',       'IPSL-CM6A-LR',             project=project)

--- a/climaf/projects/cmip6cerfacs.py
+++ b/climaf/projects/cmip6cerfacs.py
@@ -10,7 +10,8 @@ Syntax for these attributes is described in `the CMIP6 DRS document <https://goo
 
 Example for a CMIP6 dataset declaration ::
 
- >>> tas1pc=ds(project='CMIP6', model='CNRM-CM6-1', experiment='1pctCO2', variable='tas', table='Amon', realization='r3i1p1f2', period='1860-1861')
+ >>> tas1pc=ds(project='CMIP6', model='CNRM-CM6-1', experiment='1pctCO2', variable='tas', table='Amon',
+ ...           realization='r3i1p1f2', period='1860-1861')
 
 
 

--- a/climaf/projects/cordex.py
+++ b/climaf/projects/cordex.py
@@ -43,14 +43,14 @@ if root:
                '${variable}_${CORDEX_domain}_${driving_model}_${extent_experiment}_${realization}_${model}_' \
                '${model_version}_${frequency}_${PERIOD}.nc'
     patternfx = '${root}/CORDEX/output/${CORDEX_domain}/${institute}/${driving_model}/${experiment}/${realization}/' \
-               '${model}/${model_version}/${frequency}/${variable}/${version}/' \
-               '${variable}_${CORDEX_domain}_${driving_model}_${experiment}_${realization}_${model}_${model_version}_' \
-               'fx.nc'
+                '${model}/${model_version}/${frequency}/${variable}/${version}/' \
+                '${variable}_${CORDEX_domain}_${driving_model}_${experiment}_${realization}_${model}_${model_version}_'\
+                'fx.nc'
     # -- CORDEX
     cproject('CORDEX', 'root', 'model', 'CORDEX_domain', 'model_version', 'frequency', 'driving_model',
              'realization', 'experiment', 'version', 'institute', ensemble=['model', 'driving_model', 'realization'],
              separator='%')
-    dataloc(project='CORDEX', url=[patternfx,pattern1])
+    dataloc(project='CORDEX', url=[patternfx, pattern1])
     cdef('experiment', '*', project='CORDEX')
     cdef('model_version', '*', project='CORDEX')
 

--- a/climaf/projects/em.py
+++ b/climaf/projects/em.py
@@ -22,7 +22,7 @@ Specific facets are :
 Examples for defining an EM dataset::
 
  >>> tas= ds(project='em', simulation='GSAGNS1', variable='tas', period='1975-1976', realm="(A|Atmos)")
- >>> pr = ds(project='em', simulation="C1P60", group="SC, variable="pr"   , period="1850", realm="(O|Ocean)"))
+ >>> pr = ds(project='em', simulation="C1P60", group="SC", variable="pr", period="1850", realm="(O|Ocean)"))
 
 See other examples in :download:`examples/data_em.py <../examples/data_em.py>`
 

--- a/climaf/standard_operators.py
+++ b/climaf/standard_operators.py
@@ -412,8 +412,9 @@ def load_cdftools_operators():
             canSelectVar=True)
     #
     cscript('ccdfmxlheatcm',
-            'echo ""; tmp_file=`echo $(mktemp $TMPDIR/tmp_file.XXXXXX)`; cdo merge ${in_1} ${in_2} $tmp_file; cdfmxlheatc '
-            '$tmp_file ${opt}; mv mxlheatc.nc ${out}; rm -f mxlheatc.nc $tmp_file',
+            'echo ""; tmp_file=`echo $(mktemp $TMPDIR/tmp_file.XXXXXX)`; '
+            'cdo merge ${in_1} ${in_2} $tmp_file; cdfmxlheatc $tmp_file ${opt}; mv mxlheatc.nc ${out}; '
+            'rm -f mxlheatc.nc $tmp_file',
             _var="somxlheatc", canSelectVar=True)
 
     #
@@ -449,5 +450,5 @@ def load_cdftools_operators():
             _var="zo%s_${basin}", canSelectVar=True)
     #
     # rmse_xyt
-    cscript('rmse_xyt','cdo sqrt -fldmean -timmean -sqr -sub ${in_1} ${in_2} ${out}')
+    cscript('rmse_xyt', 'cdo sqrt -fldmean -timmean -sqr -sub ${in_1} ${in_2} ${out}')
 

--- a/climaf/standard_operators.py
+++ b/climaf/standard_operators.py
@@ -7,13 +7,11 @@ Management of CliMAF standard operators
 
 from __future__ import print_function, division, unicode_literals, absolute_import
 
-import os
-import subprocess
 
 from climaf import __path__ as cpath
 from climaf.operators import cscript, fixed_fields
 from env.clogging import clogger
-from env.site_settings import onCiclad
+from env.site_settings import *
 from env.environment import *
 
 

--- a/climaf/utils.py
+++ b/climaf/utils.py
@@ -48,3 +48,13 @@ class Climaf_Operator_Error(Exception):
 
     def __str__(self):
         return repr(self.valeur)
+
+
+class Climaf_Data_Error(Exception):
+    def __init__(self, valeur):
+        self.valeur = valeur
+        clogger.error(self.__str__())
+        # clogging.dedent(100)
+
+    def __str__(self):
+        return repr(self.valeur)

--- a/doc/API.rst
+++ b/doc/API.rst
@@ -9,7 +9,7 @@ Function names presented here are those defined by module ``climaf.api``
 and can be used 'as is' (i.e. without prefixing it by the module name)
 after executing::
 
->>> from climaf.api import *
+    >>> from climaf.api import *
 
 even if they belong to another module
 

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -227,13 +227,13 @@ Using CliMAF as a library
 If you wish to have the same facilities (shortcuts) than in interactive
 sessions, then insert ::
 
->>> from climaf.api import *
+    >>> from climaf.api import *
 
 in each module making use of CliMAF functions. 
 
 But you may prefer to make only explicit imports, and then use::
 
->>> import climaf
+    >>> import climaf
 
 In that case: 
 

--- a/doc/news.rst
+++ b/doc/news.rst
@@ -8,6 +8,19 @@ Changes, newest first:
 
 - running:
 
+  - **Scalar values computed using :py:func:`~climaf.driver.cvalue` are now cached**; users can reset the
+    corresponding in-memory and disk caches (both together) using :py:func:`~climaf.cache.raz_cvalues`.
+    Variable cache.handle_cvalues allows (when set to False) to de-activate this cache.
+
+        - Note : function cvalue now returns a Python float (instead of a numpy.float64)
+
+	- Internals :
+	   - this uses an in-memory dict (cache.cvalues) and a Json file (cvalues.json);
+	   - by default, the dict key is the hashed CRS of cvalue's object argument (with cvalue's index argument as suffix)
+	   - variable cache.handle_cvalues can be set to
+	       - False, for de-activating the cache
+               - 'by_crs', for using the objects CRS has dict key value (but some CRS are very long)
+
   - New operators :doc:`scripts/ccdo2_flip` and `ccdo3_flip` allow CliMAF to keep track of the variable 
     available as output of those CDO operators which use an ancilary field as first
     argument (as e.g. 'ifthen' and 'ifthenelse' ).

--- a/examples/ann_cycle.py
+++ b/examples/ann_cycle.py
@@ -3,7 +3,7 @@
 
 from __future__ import print_function, division, unicode_literals, absolute_import
 
-# Computig and plotting an annual cycle
+# Computing and plotting an annual cycle
 
 # Load Climaf functions
 from climaf.api import *

--- a/examples/atlasoce.py
+++ b/examples/atlasoce.py
@@ -4,7 +4,6 @@
 from __future__ import print_function, division, unicode_literals, absolute_import
 
 
-import os
 from optparse import OptionParser
 
 from climaf.api import *

--- a/examples/atlasoce.py
+++ b/examples/atlasoce.py
@@ -196,3 +196,4 @@ def spare_code():
             url="${root}/${simulation}/${simulation}_1m_YYYYMMDD_YYYYMMDD_grid_${variable}.nc")
     calias("dmc", 'tos', filenameVar='T')
     tos = ds(project='dmc', simulation='O1IAF01', variable='tos', period='1980')
+    print(tos)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ cftime==1.0.3.4
 # Cython>0.15.1
 # cartopy==0.17
 # python-dateutil
+natsort

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ cftime==1.0.3.4
 # cartopy==0.17
 # python-dateutil
 natsort
+sphinxcontrib-napoleon

--- a/scripts/ensemble_time_series_plot.py
+++ b/scripts/ensemble_time_series_plot.py
@@ -50,35 +50,48 @@ parser = argparse.ArgumentParser(description='Plot script for CliMAF that handle
 # -- Describe the arguments you need
 # --------------------------------------------------------------------------------------------------
 # --> filenames = ${ins} in cscript
-parser.add_argument('--filenames', action='store', help='Netcdf files provided by CliMAF')
+parser.add_argument('--filenames', action='store',
+                    help='Netcdf files provided by CliMAF')
 # --> labels = ${labels} (automatically provided by CliMAF in cscript)
-parser.add_argument('--labels', action='store', default=None, help='Labels (automatically provided by CliMAF) with ${labels} in cscript')
+parser.add_argument('--labels', action='store', default=None,
+                    help='Labels (automatically provided by CliMAF) with ${labels} in cscript')
 # --> outfig = ${out}
 parser.add_argument('--outfig', action='store', default='fig.png',
                     help='path/filename of the output figure (png)')
-parser.add_argument('--variable', action='store', default=None, help='variable')
+parser.add_argument('--variable', action='store', default=None,
+                    help='variable')
 # --> colors = ${colors}
-parser.add_argument('--colors', action='store', default=None, help='colors separated by commas')
-parser.add_argument('--lw', action='store', default=None, help='lines thicknesses (commas separated)')
-parser.add_argument('--alphas', action='store', default=None, help='lines opacity (commas separated, 0 = transparent, 1=opac)')
-parser.add_argument('--linestyles', action='store', default=None, help='lines styles (https://matplotlib.org/3.1.0/gallery/lines_bars_and_markers/linestyles.html)')
+parser.add_argument('--colors', action='store', default=None,
+                    help='colors separated by commas')
+parser.add_argument('--lw', action='store', default=None,
+                    help='lines thicknesses (commas separated)')
+parser.add_argument('--alphas', action='store', default=None,
+                    help='lines opacity (commas separated, 0 = transparent, 1=opac)')
+parser.add_argument('--linestyles', action='store', default=None,
+                    help='lines styles (https://matplotlib.org/3.1.0/gallery/lines_bars_and_markers/linestyles.html)')
 parser.add_argument('--highlight_period', action='store', default=None,
                     help='Highlight a period on a time series (thicker line) ; provide the periods yearstart_yearend '
                          'separated by commas (Ex: 1980_2005,1990_2000 to highlight the first period on the first '
                          'dataset, and the second period on the second dataset)')
 parser.add_argument('--highlight_period_lw', action='store', default=None,
                     help='Thickness of the highlighted period')
-parser.add_argument('--min', action='store', default=None, help='minimum value')
-parser.add_argument('--max', action='store', default=None, help='maximum value')
-parser.add_argument('--offset', action='store', default="", help='Offset')
-parser.add_argument('--scale', action='store', default="", help='Scale')
+parser.add_argument('--min', action='store', default=None,
+                    help='minimum value')
+parser.add_argument('--max', action='store', default=None,
+                    help='maximum value')
+parser.add_argument('--offset', action='store', default="",
+                    help='Offset')
+parser.add_argument('--scale', action='store', default="",
+                    help='Scale')
 parser.add_argument('--x_axis', action='store', default='Real',
                     help='Use either real x axis, or force align')
 parser.add_argument('--xlim', action='store', default='',
                     help='Provide the start date and end date to force the X axis. Ex: 1950-01-01,2005-12-31')
-parser.add_argument('--ylim', action='store', default='', help='Provide the interval for the Y axis')
+parser.add_argument('--ylim', action='store', default='',
+                    help='Provide the interval for the Y axis')
 
-parser.add_argument('--time_offset', action='store', default=None, help='Add a time offset to the beginning of the time series')
+parser.add_argument('--time_offset', action='store', default=None,
+                    help='Add a time offset to the beginning of the time series')
 
 parser.add_argument('--text', action='store', default="",
                     help='add some text in the plot; the user provides a triplet separared with commas x,y,text;'
@@ -93,53 +106,87 @@ parser.add_argument('--text_verticalalignment', action='store', default="",
 parser.add_argument('--text_horizontalalignment', action='store', default="",
                     help='Horizontal alignment of the text (separate with commas if provide several')
 
-parser.add_argument('--xlabel', action='store', default=None, help='X axis label')
-parser.add_argument('--ylabel', action='store', default=None, help='Y axis label')
-parser.add_argument('--xlabel_fontsize', action='store', default="", help='X axis label size')
-parser.add_argument('--ylabel_fontsize', action='store', default="", help='Y axis label size')
-parser.add_argument('--tick_size', action='store', default="", help='Ticks size')
+parser.add_argument('--xlabel', action='store', default=None,
+                    help='X axis label')
+parser.add_argument('--ylabel', action='store', default=None,
+                    help='Y axis label')
+parser.add_argument('--xlabel_fontsize', action='store', default="",
+                    help='X axis label size')
+parser.add_argument('--ylabel_fontsize', action='store', default="",
+                    help='Y axis label size')
+parser.add_argument('--tick_size', action='store', default="",
+                    help='Ticks size')
 
-parser.add_argument('--fig_size', action='store', default="", help='Size of the figure in inches => width*height Ex: 15*5')
+parser.add_argument('--fig_size', action='store', default="",
+                    help='Size of the figure in inches => width*height Ex: 15*5')
 
-parser.add_argument('--title', action='store', default=None, help='Title')
-parser.add_argument('--left_string', action='store', default=None, help='Left string')
-parser.add_argument('--right_string', action='store', default=None, help='Right string')
-parser.add_argument('--center_string', action='store', default=None, help='Center string')
-parser.add_argument('--title_fontsize', action='store', default="", help='Title size')
-parser.add_argument('--left_string_fontsize', action='store', default="", help='Left string size')
-parser.add_argument('--right_string_fontsize', action='store', default="", help='Right string size')
-parser.add_argument('--center_string_fontsize', action='store', default="", help='Center string size')
+parser.add_argument('--title', action='store', default=None,
+                    help='Title')
+parser.add_argument('--left_string', action='store', default=None,
+                    help='Left string')
+parser.add_argument('--right_string', action='store', default=None,
+                    help='Right string')
+parser.add_argument('--center_string', action='store', default=None,
+                    help='Center string')
+parser.add_argument('--title_fontsize', action='store', default="",
+                    help='Title size')
+parser.add_argument('--left_string_fontsize', action='store', default="",
+                    help='Left string size')
+parser.add_argument('--right_string_fontsize', action='store', default="",
+                    help='Right string size')
+parser.add_argument('--center_string_fontsize', action='store', default="",
+                    help='Center string size')
 
-parser.add_argument('--legend_colors', action='store', default='black', help='leg_colors separated by commas')
-parser.add_argument('--legend_labels', action='store', default=None, help='Labels of the legend')
+parser.add_argument('--legend_colors', action='store', default='black',
+                    help='leg_colors separated by commas')
+parser.add_argument('--legend_labels', action='store', default=None,
+                    help='Labels of the legend')
 parser.add_argument('--legend_xy_pos', action='store', default=None,
                     help='x,y Position of the corner of the box (by default = upper left corner). Example= "1.02,1"')
 parser.add_argument('--legend_loc', action='store', default=None,
                     help='Choose the corner of the legend box to specify the position of the legend box;'
                          ' by default 2 (upper left corner), take values 1, 2, 3 or 4'
                          ' (see resource loc of pyplot legend)')
-parser.add_argument('--legend_fontsize', action='store', default=None, help='Font size in the legend')
-parser.add_argument('--legend_ncol', action='store', default=None, help='Number of columns in the legend')
-parser.add_argument('--legend_frame', action='store', default="False", help='Draw the box around the legend? True/False')
-parser.add_argument('--legend_lw', action='store', default=None, help='Line widths (provide either one for all, or one by time series separated by commas')
-parser.add_argument('--draw_legend', action='store', default='True', help='Draw the legend? True/False')
-parser.add_argument('--append_custom_legend_to_default', action='store', default='False', help='Append the custom legend to the default one? True/False')
+parser.add_argument('--legend_fontsize', action='store', default=None,
+                    help='Font size in the legend')
+parser.add_argument('--legend_ncol', action='store', default=None,
+                    help='Number of columns in the legend')
+parser.add_argument('--legend_frame', action='store', default="False",
+                    help='Draw the box around the legend? True/False')
+parser.add_argument('--legend_lw', action='store', default=None,
+                    help='Line widths (provide either one for all, or one by time series separated by commas')
+parser.add_argument('--draw_legend', action='store', default='True',
+                    help='Draw the legend? True/False')
+parser.add_argument('--append_custom_legend_to_default', action='store', default='False',
+                    help='Append the custom legend to the default one? True/False')
 
 # -- Control margins
-parser.add_argument('--left_margin', action='store', default=None, help='Position of the left border of the figure in the plot')
-parser.add_argument('--right_margin', action='store', default=None, help='Position of the right border of the figure in the plot')
-parser.add_argument('--bottom_margin', action='store', default=None, help='Position of the bottom border of the figure in the plot')
-parser.add_argument('--top_margin', action='store', default=None, help='Position of the top border of the figure in the plot')
+parser.add_argument('--left_margin', action='store', default=None,
+                    help='Position of the left border of the figure in the plot')
+parser.add_argument('--right_margin', action='store', default=None,
+                    help='Position of the right border of the figure in the plot')
+parser.add_argument('--bottom_margin', action='store', default=None,
+                    help='Position of the bottom border of the figure in the plot')
+parser.add_argument('--top_margin', action='store', default=None,
+                    help='Position of the top border of the figure in the plot')
 
 
-parser.add_argument('--horizontal_lines_values', action='store', default=None, help='Y values for horizontal lines')
-parser.add_argument('--horizontal_lines_styles', action='store', default=None, help='Horizontal lines styles')
-parser.add_argument('--horizontal_lines_lw', action='store', default=None, help='Horizontal lines thickness')
-parser.add_argument('--horizontal_lines_colors', action='store', default=None, help='Horizontal lines colors')
-parser.add_argument('--vertical_lines_values', action='store', default=None, help='Y values for vertical lines')
-parser.add_argument('--vertical_lines_styles', action='store', default=None, help='vertical lines styles')
-parser.add_argument('--vertical_lines_lw', action='store', default=None, help='vertical lines thickness')
-parser.add_argument('--vertical_lines_colors', action='store', default=None, help='vertical lines colors')
+parser.add_argument('--horizontal_lines_values', action='store', default=None,
+                    help='Y values for horizontal lines')
+parser.add_argument('--horizontal_lines_styles', action='store', default=None,
+                    help='Horizontal lines styles')
+parser.add_argument('--horizontal_lines_lw', action='store', default=None,
+                    help='Horizontal lines thickness')
+parser.add_argument('--horizontal_lines_colors', action='store', default=None,
+                    help='Horizontal lines colors')
+parser.add_argument('--vertical_lines_values', action='store', default=None,
+                    help='Y values for vertical lines')
+parser.add_argument('--vertical_lines_styles', action='store', default=None,
+                    help='vertical lines styles')
+parser.add_argument('--vertical_lines_lw', action='store', default=None,
+                    help='vertical lines thickness')
+parser.add_argument('--vertical_lines_colors', action='store', default=None,
+                    help='vertical lines colors')
 
 # -- Default values
 default_left_string_fontsize = 30.
@@ -217,24 +264,24 @@ else:
 
 # -- alphas
 if args.alphas:
-    alphas_list = str.split(args.alphas,',')
-    if len(alphas_list)==1:
+    alphas_list = str.split(args.alphas, ',')
+    if len(alphas_list) == 1:
         alphas_list = alphas_list * len(filenames_list)
 else:
     alphas_list = [1] * len(filenames_list)
 
 # -- line styles
 if args.linestyles:
-    linestyles_list = str.split(args.linestyles,',')
-    if len(linestyles_list)==1:
+    linestyles_list = str.split(args.linestyles, ',')
+    if len(linestyles_list) == 1:
         linestyles_list = linestyles_list * len(filenames_list)
 else:
     linestyles_list = ['solid'] * len(filenames_list)
 for elt in linestyles_list:
     if '-' in elt:
         dumsplit = elt.split('-')
-        print((0, tuple( map(int, dumsplit[1:len(dumsplit)]) )))
-        linestyles_list[linestyles_list.index(elt)] = (0,  tuple( map(int, dumsplit[1:len(dumsplit)]) ) ) 
+        print((0, tuple(map(int, dumsplit[1:len(dumsplit)]))))
+        linestyles_list[linestyles_list.index(elt)] = (0, tuple(map(int, dumsplit[1:len(dumsplit)])))
 
 if args.highlight_period_lw:
     highlight_period_lw_list = args.highlight_period_lw.split(',')
@@ -254,7 +301,7 @@ else:
 
 # -- Plot the horizontal lines
 if args.horizontal_lines_values:
-    horizontal_lines_values_list = args.horizontal_lines_values.split( ',')
+    horizontal_lines_values_list = args.horizontal_lines_values.split(',')
     if args.horizontal_lines_lw:
         horizontal_lines_lw_list = args.horizontal_lines_lw.split(',')
     else:
@@ -262,7 +309,7 @@ if args.horizontal_lines_values:
     if len(horizontal_lines_lw_list) == 1 and len(horizontal_lines_values_list) > 1:
         horizontal_lines_lw_list = horizontal_lines_lw_list * len(horizontal_lines_values_list)
     if args.horizontal_lines_colors:
-        horizontal_lines_colors_list =  args.horizontal_lines_colors.split(',')
+        horizontal_lines_colors_list = args.horizontal_lines_colors.split(',')
     else:
         horizontal_lines_colors_list = ['black'] * len(horizontal_lines_values_list)
     if len(horizontal_lines_colors_list) == 1 and len(horizontal_lines_values_list) > 1:
@@ -294,10 +341,10 @@ for pathfilename in filenames_list:
             x = np.array(range(1, 13))
             datevar = []
         else:
-            orig_date  = str(t_unit).split(' ')[2]
-            orig_year  = int(orig_date.split('-')[0])
+            orig_date = str(t_unit).split(' ')[2]
+            orig_year = int(orig_date.split('-')[0])
             orig_month = int(orig_date.split('-')[1])
-            orig_day   = int(orig_date.split('-')[2][0:2])
+            orig_day = int(orig_date.split('-')[2][0:2])
             tvalue = [cdatetime(orig_year, orig_month, orig_day) +
                       timedelta(seconds=365.25 / 12 * 24.0 * 3600.0 * float(val)) for val in nctime]
             x = np.array(tvalue)
@@ -308,13 +355,13 @@ for pathfilename in filenames_list:
             t_cal = u"gregorian"  # or standard
         #
         #
-        tvalue = num2date(nctime, units = t_unit, calendar = t_cal)
+        tvalue = num2date(nctime, units=t_unit, calendar=t_cal)
         datevar = []
         for elt in tvalue:
             if not isinstance(elt, cdatetime):
                 if isinstance(elt, (netcdftime._netcdftime.DatetimeNoLeap, netcdftime._netcdftime.Datetime360Day,
                                     cftime.DatetimeNoLeap, cftime._cftime.DatetimeGregorian)):
-                    strdate =  elt.strftime().split(' ')[0]
+                    strdate = elt.strftime().split(' ')[0]
                     year = int(strdate.split('-')[0])
                     month = int(strdate.split('-')[1])
                     day = int(strdate.split('-')[2])
@@ -338,10 +385,10 @@ for pathfilename in filenames_list:
     y = np.squeeze(test_dat)
     if len(y.shape) > 1:
         print("input data is not 1D")
-    print('lw_list[dataset_number]',lw_list[dataset_number])
-    print('colors[dataset_number]',colors[dataset_number])
-    print('linestyles_list[dataset_number]',linestyles_list[dataset_number])
-    print('alphas_list[dataset_number]',alphas_list[dataset_number])
+    print('lw_list[dataset_number]', lw_list[dataset_number])
+    print('colors[dataset_number]', colors[dataset_number])
+    print('linestyles_list[dataset_number]', linestyles_list[dataset_number])
+    print('alphas_list[dataset_number]', alphas_list[dataset_number])
 
     handles_for_legend.append(
         # plt.plot(x,y,lw=lw_list[filenames_list.index(pathfilename)], color=colors[filenames_list.index(pathfilename)],

--- a/scripts/mcdo.py
+++ b/scripts/mcdo.py
@@ -65,11 +65,14 @@ def parse_args():
     parser.add_argument("--units", type=correct_args_type, help="Units of the variable")
     parser.add_argument("--vm", type=correct_args_type, help="")
     parser.add_argument("--test", help="Test the script, provide output file")
+    parser.add_argument("--running_climaf_tests", type=bool, default=False,
+                        help="If True, apply settings common to all sites, when needed")
 
     args = parser.parse_args()
     return dict(input_files=args.input_files, operator=args.operator, output_file=args.output_file,
                 variable=args.variable, period=args.period, region=args.region, alias=args.alias, units=args.units,
-                vm=args.vm,  apply_operator_after_merge=args.apply_operator_after_merge)
+                vm=args.vm,  apply_operator_after_merge=args.apply_operator_after_merge,
+                running_climaf_tests=args.running_climaf_tests)
 
 
 # Define several auxiliary functions
@@ -257,7 +260,8 @@ def change_to_tmp_dir(func):
 
 @change_to_tmp_dir
 def main(input_files, output_file, tmp, original_directory, variable=None, alias=None, region=None, units=None, vm=None,
-         period=None, operator=None, apply_operator_after_merge=None, test=None):
+         period=None, operator=None, apply_operator_after_merge=None, test=None,
+         running_climaf_tests=False):
     # Initialize cdo commands
     cdo_commands_before_merge = list()
     cdo_commands_for_selvar = list()
@@ -267,7 +271,7 @@ def main(input_files, output_file, tmp, original_directory, variable=None, alias
     # Find out which command must be used for cdo
     # For the time being, at most sites, must use NetCDF3 file format chained CDO
     # operations because NetCDF4 is not threadsafe there
-    if onCiclad:
+    if onCiclad and not running_climaf_tests:
         init_cdo_command = "cdo -O"
     else:
         init_cdo_command = "cdo -O -f nc"

--- a/scripts/mcdo.py
+++ b/scripts/mcdo.py
@@ -14,10 +14,8 @@ import re
 import os
 import subprocess
 import time
-import glob
 import shutil
 import six
-import copy
 
 from env.site_settings import onCiclad
 from env.clogging import clogger, clog

--- a/scripts/mcdo.py
+++ b/scripts/mcdo.py
@@ -225,6 +225,15 @@ def apply_cdo_command_on_slice(init_cdo_command, cdo_command, files_to_treat, ou
         return apply_cdo_command_on_slice(init_cdo_command, cdo_command, tmp_output_file, output_file)
 
 
+def find_tmp_filename(filename, tmp):
+    tmp_file_name = os.path.basename(filename)
+    tmp_file_path = os.path.sep.join([tmp, tmp_file_name])
+    while os.path.exists(tmp_file_path):
+        tmp_file_name = "_".join(["tmp", tmp_file_name])
+        tmp_file_path = os.path.sep.join([tmp, tmp_file_name])
+    return tmp_file_path
+
+
 def change_to_tmp_dir(func):
     def change_dir(**kwargs):
         clog("debug")

--- a/scripts/plotmap.py
+++ b/scripts/plotmap.py
@@ -14,7 +14,6 @@ import json
 from netCDF4 import Dataset
 
 import matplotlib.pyplot as plt
-import numpy as np
 import cartopy.crs as ccrs
 
 

--- a/testing/test_1.py
+++ b/testing/test_1.py
@@ -130,7 +130,7 @@ class B_CMIP5_DRS_Ciclad(unittest.TestCase):
 
     def test_selecting_files(self):
         my_file = cfile(self.ds)
-        expected = climaf.cache.currentCache +'/fe/e23d2f2ebb886d6582e6e0f3e7b3867294a5237cc5b0d32b9c537c.nc'
+        expected = climaf.cache.currentCache + '/fe/e23d2f2ebb886d6582e6e0f3e7b3867294a5237cc5b0d32b9c537c.nc'
         print("actual=" + my_file)
         print("expected=" + expected)
         self.assertEqual(my_file, expected, 'Issue extracting 1pctCO2 data files')

--- a/tests/launch_tests_with_coverage.sh
+++ b/tests/launch_tests_with_coverage.sh
@@ -33,6 +33,7 @@ if [ $run_coverage -eq 0 ] ; then
     ${run_command_line} "test_import.py"
 fi
 for module in $run_modules; do
+    echo -e "\nTesting module : $module\n"
     echo $PWD
     if [ $run_coverage -eq 0 ] ; then
         ${run_command_line} "test_${module}.py"

--- a/tests/reference_data/test_mcdo/test_1.txt
+++ b/tests/reference_data/test_mcdo/test_1.txt
@@ -1,1 +1,1 @@
-cdo -O -f nc -copy -sellevel,85000 -selname,taC -expr,taC=ta*1+-273.15 _CLIMAF_PATH_/../examples/data/AMIPV6ALB2G/A/AMIPV6ALB2GPL1980.nc _TEST_PATH_/test_1.nc
+cdo -O -f nc -copy -sellevel,85000 -selname,taC -expr,taC=ta*1+-273.15 /tmp/climaf_XXX/AMIPV6ALB2GPL1980.nc _TEST_PATH_/test_1.nc

--- a/tests/reference_data/test_mcdo/test_2.txt
+++ b/tests/reference_data/test_mcdo/test_2.txt
@@ -1,5 +1,5 @@
-cdo -O -f nc -sellonlatbox,10,350,-20,60 _CLIMAF_PATH_/../tests/test_data/tas_Amon_CNRM-CM5_historical_r1i1p1_1850.nc /tmp/climaf_XXX/tas_Amon_CNRM-CM5_historical_r1i1p1_1850.nc
-cdo -O -f nc -sellonlatbox,10,350,-20,60 _CLIMAF_PATH_/../tests/test_data/tas_Amon_CNRM-CM5_historical_r1i1p1_1851.nc /tmp/climaf_XXX/tas_Amon_CNRM-CM5_historical_r1i1p1_1851.nc
-cdo -O -f nc -sellonlatbox,10,350,-20,60 _CLIMAF_PATH_/../tests/test_data/tas_Amon_CNRM-CM5_historical_r1i1p1_1852.nc /tmp/climaf_XXX/tas_Amon_CNRM-CM5_historical_r1i1p1_1852.nc
+cdo -O -f nc -sellonlatbox,10,350,-20,60 /tmp/climaf_XXX/tas_Amon_CNRM-CM5_historical_r1i1p1_1850.nc /tmp/climaf_XXX/tmp_tas_Amon_CNRM-CM5_historical_r1i1p1_1850.nc
+cdo -O -f nc -sellonlatbox,10,350,-20,60 /tmp/climaf_XXX/tas_Amon_CNRM-CM5_historical_r1i1p1_1851.nc /tmp/climaf_XXX/tmp_tas_Amon_CNRM-CM5_historical_r1i1p1_1851.nc
+cdo -O -f nc -sellonlatbox,10,350,-20,60 /tmp/climaf_XXX/tas_Amon_CNRM-CM5_historical_r1i1p1_1852.nc /tmp/climaf_XXX/tmp_tas_Amon_CNRM-CM5_historical_r1i1p1_1852.nc
 cdo -O -f nc -mergetime /tmp/climaf_XXX/tas_Amon_CNRM-CM5_historical_r1i1p1_1850.nc /tmp/climaf_XXX/tas_Amon_CNRM-CM5_historical_r1i1p1_1851.nc /tmp/climaf_XXX/tas_Amon_CNRM-CM5_historical_r1i1p1_1852.nc /tmp/climaf_XXX/test_2.nc
 cdo -O -f nc -ymonavg -seldate,1850-06-01T00:00:00,1852-04-03T00:00:00 /tmp/climaf_XXX/test_2.nc _TEST_PATH_/test_2.nc

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -16,7 +16,7 @@ from climaf.cache import setNewUniqueCache
 from climaf.classes import cproject, cdef, Climaf_Classes_Error, cobject, cdummy, processDatasetArgs, cdataset, calias
 from climaf.period import Climaf_Period_Error, init_period
 from env.environment import *
-from env.site_settings import atCNRM
+from env.site_settings import atCNRM, onCiclad
 
 
 class CprojectTests(unittest.TestCase):
@@ -140,6 +140,8 @@ class ProcessDatasetArgsTests(unittest.TestCase):
         # TODO: Test the place on which the test is launched before this test
         if atCNRM:
             self.assertEqual(a["root"], "/cnrm/cmip")
+        elif onCiclad:
+            self.assertEqual(a["root"], "/bdd")
         else:
             self.assertEqual(a["root"], "")
         self.assertEqual(a["simulation"], "")
@@ -166,6 +168,8 @@ class ProcessDatasetArgsTests(unittest.TestCase):
         # TODO: Test the place on which the test is launched before this test
         if atCNRM:
             self.assertEqual(a["root"], "/cnrm/cmip/cnrm/ESG")
+        if onCiclad:
+            self.assertEqual(a["root"], "/bdd")
         else:
             self.assertEqual(a["root"], "")
         self.assertEqual(a["simulation"], "")
@@ -236,6 +240,8 @@ class CdatasetTests(unittest.TestCase):
         # TODO: Write the test
         if atCNRM:
             self.root = "/cnrm/cmip/cnrm/ESG"
+        if onCiclad:
+            self.root = "/bdd"
         else:
             self.root = ""
         self.my_dataset = cdataset(project='CMIP5', model='CNRM-CM5', experiment='historical', frequency='monthly',

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -84,17 +84,11 @@ class CobjectTests(unittest.TestCase):
     def test_cobject_init(self):
         self.assertEqual(self.my_object.crs, "void")
 
-    #@unittest.expectedFailure
     def test_cobject_str(self):
-        # TODO: Modify CliMAF to raise an exception
-        with self.assertRaises(NotImplementedError):
-            str(self.my_object)
+        self.assertEqual(str(self.my_object), "void")
 
-    #@unittest.expectedFailure
     def test_cobject_repr(self):
-        # TODO: Modify CliMAF to raise an exception
-        with self.assertRaises(NotImplementedError):
-            str(self.my_object)
+        self.assertEqual(repr(self.my_object), "void")
 
     @unittest.expectedFailure
     def test_cobject_register(self):

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -168,7 +168,7 @@ class ProcessDatasetArgsTests(unittest.TestCase):
         # TODO: Test the place on which the test is launched before this test
         if atCNRM:
             self.assertEqual(a["root"], "/cnrm/cmip/cnrm/ESG")
-        if onCiclad:
+        elif onCiclad:
             self.assertEqual(a["root"], "/bdd")
         else:
             self.assertEqual(a["root"], "")
@@ -240,7 +240,7 @@ class CdatasetTests(unittest.TestCase):
         # TODO: Write the test
         if atCNRM:
             self.root = "/cnrm/cmip/cnrm/ESG"
-        if onCiclad:
+        elif onCiclad:
             self.root = "/bdd"
         else:
             self.root = ""

--- a/tests/test_example_index_html.py
+++ b/tests/test_example_index_html.py
@@ -48,6 +48,9 @@ class HtmlIndexCreation(unittest.TestCase):
         self.reference_directory = os.sep.join(cpath + ["..", "tests", "reference_data", "test_index_html"])
         self.reference_index_1 = os.sep.join([self.reference_directory, "index_1.html"])
         self.reference_index_2 = os.sep.join([self.reference_directory, "index_2.html"])
+        # Need to overwrite IPSL's very extensive variables definitions, at leat for "rst"
+        # This in order to run the tests also at IPSL
+        derived_variables["*"].pop("rst",None)
 
     def test_html_index_1(self):
         # Start the index

--- a/tests/test_example_index_html.py
+++ b/tests/test_example_index_html.py
@@ -50,7 +50,7 @@ class HtmlIndexCreation(unittest.TestCase):
         self.reference_index_2 = os.sep.join([self.reference_directory, "index_2.html"])
         # Need to overwrite IPSL's very extensive variables definitions, at leat for "rst"
         # This in order to run the tests also at IPSL
-        derived_variables["*"].pop("rst",None)
+        derived_variables["*"].pop("rst", None)
 
     def test_html_index_1(self):
         # Start the index

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -103,12 +103,12 @@ class OpenTableTests(unittest.TestCase):
                                                   COLUMNS=template_columns.safe_substitute(LABEL="a column")))
         self.assertEqual(open_table(columns=["a column", "an other one"]),
                          template.safe_substitute(SPACING=5, TITLE="",
-                                                  COLUMNS="".join([template_columns.safe_substitute(LABEL=l) for l in
-                                                                   ["a column", "an other one"]])))
+                                                  COLUMNS="".join([template_columns.safe_substitute(LABEL=lab)
+                                                                   for lab in ["a column", "an other one"]])))
         self.assertEqual(open_table(columns=["a column", "an other one"], title="A title", spacing=9),
                          template.safe_substitute(SPACING=9, TITLE="A title",
-                                                  COLUMNS="".join([template_columns.safe_substitute(LABEL=l) for l in
-                                                                   ["a column", "an other one"]])))
+                                                  COLUMNS="".join([template_columns.safe_substitute(LABEL=lab)
+                                                                   for lab in ["a column", "an other one"]])))
 
 
 class CloseTableTests(unittest.TestCase):

--- a/tests/test_mcdo.py
+++ b/tests/test_mcdo.py
@@ -41,7 +41,8 @@ class McdoTests(unittest.TestCase):
         ref_output_file = os.path.sep.join([self.ref_dir, output_file])
         mcdo_main(input_files=[self.input_file_1], output_file=test_output_file,
                   variable="ta", alias=["taC", "ta", "1", "-273.15"], region=None, units=None, vm=None,
-                  period=None, operator="sellevel,85000", apply_operator_after_merge=False, test=test_log)
+                  period=None, operator="sellevel,85000", apply_operator_after_merge=False, test=test_log,
+                  running_climaf_tests=True)
         compare_text_files(test_log, ref_log, _CLIMAF_PATH_=rootpath[0], _TEST_PATH_=tmp_directory)
         compare_netcdf_files(test_output_file, ref_output_file)
 
@@ -55,7 +56,7 @@ class McdoTests(unittest.TestCase):
         mcdo_main(input_files=[self.input_file_2, self.input_file_3, self.input_file_4], output_file=test_output_file,
                   variable="tas", alias=None, region=["-20", "60", "10", "350"], units=None, vm=None,
                   period="1850-06-01T00:00:00,1852-04-03T00:00:00", operator="ymonavg", apply_operator_after_merge=True,
-                  test=test_log)
+                  test=test_log, running_climaf_tests=True)
         compare_text_files(test_log, ref_log, _CLIMAF_PATH_=rootpath[0], _TEST_PATH_=tmp_directory)
         compare_netcdf_files(test_output_file, ref_output_file)
 

--- a/tests/test_operators_derive.py
+++ b/tests/test_operators_derive.py
@@ -66,6 +66,7 @@ class DerivedVariableTest(unittest.TestCase):
         self.assertEqual(derived_variable("rscre", "erai"), ("minus", "rscre", ["rs", "rscs"], {}))
         self.assertEqual(derived_variable("ta", "erai"), ('rescale', 'ta', ['t'], {'scale': 1.0, 'offset': 0.0}))
 
+
 if __name__ == '__main__':
     # Jump into the test directory
     tmp_directory = "/".join([os.environ["HOME"], "tmp", "tests", "test_operators"])

--- a/tests/tools_for_tests.py
+++ b/tests/tools_for_tests.py
@@ -96,7 +96,7 @@ def compare_text_files(file_test, file_ref, **kwargs):
     for (key, value) in kwargs.items():
         content_test = content_test.replace(key, value)
         content_ref = content_ref.replace(key, value)
-    content_test = re.sub(os.path.sep.join([os.environ.get("TMPDIR", "/tmp"), "climaf_\w+"]), "/tmp/climaf_XXX",
+    content_test = re.sub(os.path.sep.join([os.environ.get("TMPDIR", "/tmp"), r"climaf_\w+"]), "/tmp/climaf_XXX",
                           content_test)
     if content_test != content_ref:
         raise ValueError("The content of files %s and %s are different:\n%s\n%s" % (file_test, file_ref, content_test,


### PR DESCRIPTION
@jservon may appreciate the addition of a cache for scalars, which he asked for some years ago. This is a cache only for results of function cvalue(). I became convinced when practising by myself the computation of myriads of indices . See new.rst for details. The increase in performance is quite convincing on some use cases

Also, in the same context (multiple indices base on multi-model analysis), I was impressed by the size of CRS expressions (some Mega bytes), their memory footprint, and by the time taken re-computing it. Digging a bit, there was numerous re-computation of the CRS occurring for each object (each time it was involved in an expression). I fixed that. But I cannot guarantee that macros still work fine