### PR TITLE
Improve cache robstness, fixes for Cmip5 and a few other minor issues

### DIFF
--- a/climaf/anynetcdf.py
+++ b/climaf/anynetcdf.py
@@ -20,7 +20,7 @@ except ImportError:
             except ImportError:
                 clogger.critical(
                     "Netcdf handling is yet available only with modules Scientific.IO.Netcdf or NetCDF4 or "
-                    "scipy.io.netcdf ")
+                    "or netCDF4 or scipy.io.netcdf ")
                 exit()
                 # raise Climaf_Netcdf_Error("Netcdf handling is yet available only with modules Scientific.IO.Netcdf or
                 #                            NetCDF4 or scipy.io.netcdf ")

--- a/climaf/cache.py
+++ b/climaf/cache.py
@@ -94,14 +94,15 @@ def generateUniqueFileName(expression, format="nc", option="new", create_dirs=Tr
         if create_dirs:
             dirn = os.path.dirname(rep)
             if not os.path.exists(dirn):
-                try : os.makedirs(dirn)
-                except OSError :
-                    if os.path.exists(dirn) :
+                try:
+                    os.makedirs(dirn)
+                except OSError:
+                    if os.path.exists(dirn):
                         # Happens when two concurrent CliMAF are
                         # creating numerous cache files
                         pass
-                    else :
-                        raise Climaf_Cache_Error("Cannot create dir "% dirn)
+                    else:
+                        raise Climaf_Cache_Error("Cannot create dir " % dirn)
         if os.path.islink(rep) and not os.path.exists(os.path.realpath(rep)):
             os.remove(rep)
         clogger.debug("returning %s" % rep)
@@ -868,7 +869,7 @@ def clist(size="", age="", access=0, pattern="", not_pattern="", usage=False, co
     len_new_dict = len(new_dict)
 
     # request on new dictionary through usage, count and remove
-    work_dic = new_dict if (var_find or pattern  != "" or not_pattern  != "") else crs2filename
+    work_dic = new_dict if (var_find or pattern != "" or not_pattern != "") else crs2filename
 
     if usage is True and len_new_dict != 0:
         # construction of a dictionary containing crs and disk-usage associated
@@ -923,7 +924,7 @@ def clist(size="", age="", access=0, pattern="", not_pattern="", usage=False, co
 
     elif remove is True and len_new_dict != 0:
         print("Removed files:")
-        if var_find or pattern  != "" or not_pattern  != "":
+        if var_find or pattern != "" or not_pattern != "":
             list_tmp_crs = list(new_dict)
         else:
             list_tmp_crs = list(crs2filename)
@@ -932,7 +933,7 @@ def clist(size="", age="", access=0, pattern="", not_pattern="", usage=False, co
         return list(map(crewrite, list_tmp_crs))
 
     else:  # usage, count and remove are False
-        if var_find or pattern  != "" or not_pattern  != "":
+        if var_find or pattern != "" or not_pattern != "":
             if len(new_dict) != 0:
                 if new_dict != crs2filename:
                     print("Filtered objects :")
@@ -948,7 +949,7 @@ def clist(size="", age="", access=0, pattern="", not_pattern="", usage=False, co
     if special is True:
         global dic_special
         dic_special = dict()
-        if var_find is True or pattern  != "" or not_pattern  != "":
+        if var_find is True or pattern != "" or not_pattern != "":
             dic_special = new_dict.copy()
         else:
             dic_special = crs2filename.copy()

--- a/climaf/cache.py
+++ b/climaf/cache.py
@@ -868,7 +868,7 @@ def clist(size="", age="", access=0, pattern="", not_pattern="", usage=False, co
     len_new_dict = len(new_dict)
 
     # request on new dictionary through usage, count and remove
-    work_dic = new_dict if (var_find or pattern is not "" or not_pattern is not "") else crs2filename
+    work_dic = new_dict if (var_find or pattern  != "" or not_pattern  != "") else crs2filename
 
     if usage is True and len_new_dict != 0:
         # construction of a dictionary containing crs and disk-usage associated
@@ -923,7 +923,7 @@ def clist(size="", age="", access=0, pattern="", not_pattern="", usage=False, co
 
     elif remove is True and len_new_dict != 0:
         print("Removed files:")
-        if var_find or pattern is not "" or not_pattern is not "":
+        if var_find or pattern  != "" or not_pattern  != "":
             list_tmp_crs = list(new_dict)
         else:
             list_tmp_crs = list(crs2filename)
@@ -932,7 +932,7 @@ def clist(size="", age="", access=0, pattern="", not_pattern="", usage=False, co
         return list(map(crewrite, list_tmp_crs))
 
     else:  # usage, count and remove are False
-        if var_find or pattern is not "" or not_pattern is not "":
+        if var_find or pattern  != "" or not_pattern  != "":
             if len(new_dict) != 0:
                 if new_dict != crs2filename:
                     print("Filtered objects :")
@@ -948,7 +948,7 @@ def clist(size="", age="", access=0, pattern="", not_pattern="", usage=False, co
     if special is True:
         global dic_special
         dic_special = dict()
-        if var_find is True or pattern is not "" or not_pattern is not "":
+        if var_find is True or pattern  != "" or not_pattern  != "":
             dic_special = new_dict.copy()
         else:
             dic_special = crs2filename.copy()

--- a/climaf/classes.py
+++ b/climaf/classes.py
@@ -1764,7 +1764,7 @@ class cpage(cpage_all):
                  orientation=None,
                  page_width=1000., page_height=1500., title="", x=0, y=26, ybox=50, pt=24,
                  font="Times-New-Roman", gravity="North", background="white",
-                 insert="", insert_width=0):
+                 insert="", insert_width=200):
         """
         Builds a CliMAF cpage object, which represents an array of figures (output:
         'png' or 'pdf' figure)

--- a/climaf/dataloc.py
+++ b/climaf/dataloc.py
@@ -310,6 +310,7 @@ def selectFiles(return_wildcards=None, merge_periods_on=None, **kwargs):
         if len(rep) == 0:
             clogger.warning("no file found for %s, at these "
                             "data locations %s " % (repr(kwargs), repr(urls)))
+            clogger.warning("i.e. at "+ str([ url.replace("${PERIOD}","$PERIOD").replace("$","").format(**kwargs) for url in urls ])) 
             if any([kwargs[k] == '' for k in kwargs]):
                 clogger.warning("Please check these empty attributes %s" % [k for k in kwargs if kwargs[k] == ''])
             return None

--- a/climaf/dataloc.py
+++ b/climaf/dataloc.py
@@ -310,7 +310,8 @@ def selectFiles(return_wildcards=None, merge_periods_on=None, **kwargs):
         if len(rep) == 0:
             clogger.warning("no file found for %s, at these "
                             "data locations %s " % (repr(kwargs), repr(urls)))
-            clogger.warning("i.e. at "+ str([ url.replace("${PERIOD}","$PERIOD").replace("$","").format(**kwargs) for url in urls ])) 
+            clogger.warning("i.e. at " + str([url.replace("${PERIOD}", "$PERIOD").replace("$", "").format(**kwargs)
+                                              for url in urls]))
             if any([kwargs[k] == '' for k in kwargs]):
                 clogger.warning("Please check these empty attributes %s" % [k for k in kwargs if kwargs[k] == ''])
             return None

--- a/climaf/driver.py
+++ b/climaf/driver.py
@@ -712,7 +712,7 @@ def ceval_script(scriptCall, deep, recurse_list=[]):
                 inValue = ceval(op, userflags=scriptCall.flags, format='file', deep=deep,
                                 recurse_list=recurse_list)
             clogger.debug("evaluating %s operand %s as %s" % (scriptCall.operator, op, inValue))
-            if inValue is None or inValue is "":
+            if inValue is None or inValue  == "":
                 raise Climaf_Driver_Error("When evaluating %s : value for %s is None" % (scriptCall.script, repr(op)))
             if isinstance(inValue, list):
                 size = len(inValue)
@@ -774,7 +774,7 @@ def ceval_script(scriptCall, deep, recurse_list=[]):
             opscrs += op.crs + " - "
         # print("processing %s, i=%d"%(`op`,i))
         infile = invalues[i]
-        if (scriptCall.operator != 'remote_select') and infile is not '' and \
+        if (scriptCall.operator != 'remote_select') and infile != '' and \
                 not all(map(os.path.exists, infile.split(" "))):
             raise Climaf_Driver_Error("Internal error : some input file does not exist among %s:" % infile)
         i += 1
@@ -1381,9 +1381,9 @@ def cfilePage(cobj, deep, recurse_list=None):
     ymargin = 30.  # Vertical shift between figures
     #
     usable_height = cobj.page_height - ymargin * (len(cobj.heights) - 1.) - y_top_margin - y_bot_margin
-    if cobj.title is not "":
+    if cobj.title != "":
         usable_height -= cobj.ybox
-    if cobj.insert is not "":
+    if cobj.insert != "":
         ins_base_width, ins_base_height = get_fig_sizes(cobj.insert)
         insert_height = int((float(ins_base_height) * cobj.insert_width) / float(ins_base_width))
         usable_height -= insert_height

--- a/climaf/driver.py
+++ b/climaf/driver.py
@@ -1035,6 +1035,9 @@ def cread(datafile, varname=None, period=None):
             clogger.warning("Cannot yet select on period (%s) using CMa for files %s - TBD" % (period, datafile))
         from .anynetcdf import ncf
         fileobj = ncf(datafile)
+        if varname not in fileobj.variables :
+            clogger.error("File %s doesn't have requested variable %s, only %s"%\
+                          (datafile,varname,fileobj.variables) )
         # Note taken from the CDOpy developper : .data is not backwards
         # compatible to old scipy versions, [:] is
         data = fileobj.variables[varname][:]

--- a/climaf/driver.py
+++ b/climaf/driver.py
@@ -712,7 +712,7 @@ def ceval_script(scriptCall, deep, recurse_list=[]):
                 inValue = ceval(op, userflags=scriptCall.flags, format='file', deep=deep,
                                 recurse_list=recurse_list)
             clogger.debug("evaluating %s operand %s as %s" % (scriptCall.operator, op, inValue))
-            if inValue is None or inValue  == "":
+            if inValue in [None, ""]:
                 raise Climaf_Driver_Error("When evaluating %s : value for %s is None" % (scriptCall.script, repr(op)))
             if isinstance(inValue, list):
                 size = len(inValue)
@@ -1035,9 +1035,9 @@ def cread(datafile, varname=None, period=None):
             clogger.warning("Cannot yet select on period (%s) using CMa for files %s - TBD" % (period, datafile))
         from .anynetcdf import ncf
         fileobj = ncf(datafile)
-        if varname not in fileobj.variables :
-            clogger.error("File %s doesn't have requested variable %s, only %s"%\
-                          (datafile,varname,fileobj.variables) )
+        if varname not in fileobj.variables:
+            clogger.error("File %s doesn't have requested variable %s, only %s" %
+                          (datafile, varname, fileobj.variables))
         # Note taken from the CDOpy developper : .data is not backwards
         # compatible to old scipy versions, [:] is
         data = fileobj.variables[varname][:]

--- a/climaf/html.py
+++ b/climaf/html.py
@@ -202,7 +202,7 @@ def link(label, filename, thumbnail=None, hover=True):
                             int(hover)
                         except:
                             raise Climaf_Html_Error("If hover is a not empty string, it must "
-                                                    "contain width and/or height, separaed by 'x' or '*'")
+                                                    "contain width and/or height, separated by 'x' or '*'")
 
                         hover_width = hover
                         hover_height = hover
@@ -496,6 +496,16 @@ def fline(func, farg, sargs, title=None,
 # cinstantiate("index.html","inst.html")
 
 
+def exec_and_discard_test(m, should_exec):
+        expression = m.group(1)
+        if should_exec:
+            # print "Executing %s"%expression
+            # try :
+            exec(expression, globals())
+            # except :
+            #    print "Issue executing %s"%expression
+        return ""
+
 def cinstantiate(objin, filout=None, should_exec=True):
     """ Read file or string 'objin', extract parts of text surrounded by 'Â£',
     evaluate them as Python assignments or expressions, replaces
@@ -506,15 +516,6 @@ def cinstantiate(objin, filout=None, should_exec=True):
      If assign is False, assignements will not be executed
     """
 
-    def exec_and_discard_test(m):
-        expression = m.group(1)
-        if should_exec:
-            # print "Executing %s"%expression
-            # try :
-            exec(expression, globals())
-            # except :
-            #    print "Issue executing %s"%expression
-        return ""
 
     #
     def replace_text_with_evaluation(m):

--- a/climaf/html.py
+++ b/climaf/html.py
@@ -497,14 +497,15 @@ def fline(func, farg, sargs, title=None,
 
 
 def exec_and_discard_test(m, should_exec):
-        expression = m.group(1)
-        if should_exec:
-            # print "Executing %s"%expression
-            # try :
-            exec(expression, globals())
-            # except :
-            #    print "Issue executing %s"%expression
-        return ""
+    expression = m.group(1)
+    if should_exec:
+        # print "Executing %s"%expression
+        # try :
+        exec(expression, globals())
+        # except :
+        #    print "Issue executing %s"%expression
+    return ""
+
 
 def cinstantiate(objin, filout=None, should_exec=True):
     """ Read file or string 'objin', extract parts of text surrounded by 'Â£',
@@ -515,8 +516,6 @@ def cinstantiate(objin, filout=None, should_exec=True):
 
      If assign is False, assignements will not be executed
     """
-
-
     #
     def replace_text_with_evaluation(m):
         expression = m.group(1)

--- a/climaf/projects/cmip5.py
+++ b/climaf/projects/cmip5.py
@@ -43,7 +43,7 @@ if True:
     # ------------------------------------ >
     cproject('CMIP5_extent', 'root', 'model', 'table', 'experiment', 'extent_experiment', 'realization', 'frequency',
              'realm',
-             'version', ensemble=['model', 'realization'], separator='%')
+             'version', 'extent_version', ensemble=['model', 'realization'], separator='%')
 
     # -- Define the pattern for CMIP5
     if atCNRM:
@@ -65,7 +65,7 @@ if True:
 
     # -- And the additionnal pattern for extent
     pattern2 = '${root}/CMIP5/output*/*/${model}/${extent_experiment}/${frequency}/${realm}/${table}/${realization}/' \
-               '${version}/${variable}/'
+               '${extent_version}/${variable}/'
     pattern2 += '${variable}_${table}_${model}_${extent_experiment}_${realization}_${PERIOD}.nc'
 
     # -- call the dataloc CliMAF function

--- a/climaf/projects/cmip5.py
+++ b/climaf/projects/cmip5.py
@@ -54,7 +54,11 @@ if True:
                    '${realization}/${version}/${variable}/'
 
     # a pattern for fixed fields
-    patternf = pattern1 + '${variable}_${table}_${model}_${experiment}_${realization}.nc'
+    patternf = pattern1 + '${variable}_${table}_${model}_${experiment}_r0i0p0.nc'
+    patternf=patternf.replace("/${realization}","/r0i0p0").replace("/${version}","/latest")
+    patternf=patternf.replace("/${frequency}","/fx").replace("/${table}","/fx")
+    # On Ciclad, some fixed fields don't have the last (per-variable) directories level
+    patternf2=patternf.replace("/${variable}/","/")
 
     # The pattern for fields with a period
     pattern1 += '${variable}_${table}_${model}_${experiment}_${realization}_${PERIOD}.nc'
@@ -68,6 +72,7 @@ if True:
     # -- CMIP5
     dataloc(project='CMIP5', organization='generic', url=pattern1)
     dataloc(project='CMIP5', organization='generic', url=patternf)
+    dataloc(project='CMIP5', organization='generic', url=patternf2)
     # -- CMIP5_extent
     dataloc(project='CMIP5_extent', organization='generic', url=pattern1)
     dataloc(project='CMIP5_extent', organization='generic', url=pattern2)

--- a/climaf/projects/cmip5.py
+++ b/climaf/projects/cmip5.py
@@ -55,10 +55,10 @@ if True:
 
     # a pattern for fixed fields
     patternf = pattern1 + '${variable}_${table}_${model}_${experiment}_r0i0p0.nc'
-    patternf=patternf.replace("/${realization}","/r0i0p0").replace("/${version}","/latest")
-    patternf=patternf.replace("/${frequency}","/fx").replace("/${table}","/fx")
+    patternf = patternf.replace("/${realization}", "/r0i0p0").replace("/${version}", "/latest")
+    patternf = patternf.replace("/${frequency}", "/fx").replace("/${table}", "/fx")
     # On Ciclad, some fixed fields don't have the last (per-variable) directories level
-    patternf2=patternf.replace("/${variable}/","/")
+    patternf2 = patternf.replace("/${variable}/", "/")
 
     # The pattern for fields with a period
     pattern1 += '${variable}_${table}_${model}_${experiment}_${realization}_${PERIOD}.nc'


### PR DESCRIPTION
When applying CAMMAC to CMIP5, a few issues appeared. This PR does fix it. @jservon may wish to check that.

Concurrent Climaf jobs could defeat the cache, as noted also by Ionela (mail, dated july, 9, 2021); this is improved.

Tested on Ciclad using launch_tests_with_coverage.sh with python 2 (and 3) using 'module load climaf/2.0.0 (resp.  climaf/2.0.0-python3.6 ) 