### PR TITLE
Cdu fix

### DIFF
--- a/climaf/cache.py
+++ b/climaf/cache.py
@@ -913,7 +913,10 @@ def clist(size="", age="", access=0, pattern="", not_pattern="", usage=False, co
         dic_usage = dict()
         tmp = ""
         for crs in work_dic:
-            tmp += work_dic[crs] + " "
+            if isinstance(work_dic[crs], tuple):
+                tmp += work_dic[crs][0] + " "
+            if isinstance(work_dic[crs], str):
+                tmp += work_dic[crs] + " "
         res = os.popen("du -sc %s" % tmp).read()
 
         regex = re.compile('([0-9]+)\t')

--- a/climaf/functions.py
+++ b/climaf/functions.py
@@ -872,7 +872,7 @@ def iplot_members(ens, nplot=12, N=1, **pp):
     if start > len(members):
         return 'The list of members is shorter than what you asked; specify smaller N or nplot'
     if end > len(members):
-        end = -1
+        end = len(members)
     members_selection = members[start:end]
     for mem in ens:
         if mem not in members_selection:

--- a/climaf/standard_operators.py
+++ b/climaf/standard_operators.py
@@ -328,6 +328,11 @@ def load_standard_operators():
             _var='curltau')
 
     #
+    # rmse_xyt
+    cscript(
+        'rmse_xyt', 'cdo sqrt -fldmean -timmean -sqr -sub ${in_1} ${in_2} ${out}')
+    #
+
     if os.system("type cdfmean >/dev/null 2>&1") == 0:
         load_cdftools_operators()
     else:
@@ -465,6 +470,3 @@ def load_cdftools_operators():
             'zo${Var}_${basin} tmpfile.nc ${out}; rm -f tmpfile.nc zonalmean.nc',
             _var="zo%s_${basin}", canSelectVar=True)
     #
-    # rmse_xyt
-    cscript(
-        'rmse_xyt', 'cdo sqrt -fldmean -timmean -sqr -sub ${in_1} ${in_2} ${out}')


### PR DESCRIPTION
There was an error on cdu():
```
cdu()
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[9], line 1
----> 1 cdu(size='3M', count=True)

File /net/nfs/tools/Users/SU/jservon/climaf_installs/V3.0_IPSL1/climaf/cache.py:1040, in cdu(**kwargs)
   1038 kwargs['usage'] = True
   1039 kwargs['remove'] = False
-> 1040 return clist(**kwargs)

File /net/nfs/tools/Users/SU/jservon/climaf_installs/V3.0_IPSL1/climaf/cache.py:916, in clist(size, age, access, pattern, not_pattern, usage, count, remove, CRS, special)
    914 tmp = ""
    915 for crs in work_dic:
--> 916     tmp += work_dic[crs] + " "
    917 res = os.popen("du -sc %s" % tmp).read()
    919 regex = re.compile('([0-9]+)\t')

TypeError: can only concatenate tuple (not "str") to tuple
```
I replaced line 916 with:
            if isinstance(work_dic[crs], tuple):
                tmp += work_dic[crs][0] + " "
            if isinstance(work_dic[crs], str):
                tmp += work_dic[crs] + " "

