### PR TITLE
Save load ensemble object

### DIFF
--- a/climaf/cache.py
+++ b/climaf/cache.py
@@ -913,7 +913,10 @@ def clist(size="", age="", access=0, pattern="", not_pattern="", usage=False, co
         dic_usage = dict()
         tmp = ""
         for crs in work_dic:
-            tmp += work_dic[crs] + " "
+            if isinstance(work_dic[crs], tuple):
+                tmp += work_dic[crs][0] + " "
+            if isinstance(work_dic[crs], str):
+                tmp += work_dic[crs] + " "
         res = os.popen("du -sc %s" % tmp).read()
 
         regex = re.compile('([0-9]+)\t')

--- a/climaf/functions.py
+++ b/climaf/functions.py
@@ -872,7 +872,7 @@ def iplot_members(ens, nplot=12, N=1, **pp):
     if start > len(members):
         return 'The list of members is shorter than what you asked; specify smaller N or nplot'
     if end > len(members):
-        end = -1
+        end = len(members)
     members_selection = members[start:end]
     for mem in ens:
         if mem not in members_selection:

--- a/climaf/functions.py
+++ b/climaf/functions.py
@@ -17,6 +17,9 @@ from climaf import classes
 from climaf import cachedir
 
 
+
+
+
 def cscalar(dat):
     """ Returns a scalar value using cMA (and not a masked array,
         to avoid the subsetting that is generally needed).
@@ -882,3 +885,46 @@ def iplot_members(ens, nplot=12, N=1, **pp):
     mp = cpage(plot(new_ens, **pp))
 
     return iplot(mp)
+
+
+
+def save_ensemble_object(ens, outfilename = 'ensemble_object.json'):
+    '''
+    Takes an ensemble object ens (first argument) and saves it in a json file outfilename
+    (second argument).
+    It converts the CliMAF objects of the ensemble to strings to allow saving the ensemble dictionary in a json file.
+    Use load_ensemble_object on the json file produced by save_ensemble_object to get your ensemble back.
+    '''
+    import json
+    # -- Need to convert the CliMAF objects to string
+    save_json_dict = dict()
+    for elt in ens:
+        save_json_dict[elt] = str(ens[elt])
+
+    with open(outfilename, "w") as outfile:
+        json.dump(save_json_dict, outfile)
+    print('Saved ensemble object in : '+outfilename)
+    print('Use load_ensemble_object to load it back as a CliMAF ensemble')
+
+
+def load_ensemble_object(filename):
+    '''
+    Takes the name of the json file containing the dictionary of the ensemble you saved with save_ensemble_object
+    and returns a ready-to-use CliMAF ensemble object.
+    '''
+
+    import json
+
+    with open(filename, 'r') as openfile:
+        # Reading from json file
+        my_tmp_ens_dict = json.load(openfile)
+
+    # -- Convert the strong back to CliMAF objects
+    myens_dict = dict()
+    for elt in my_tmp_ens_dict:
+        myens_dict[elt] = eval(my_tmp_ens_dict[elt])
+
+    myens = cens(myens_dict)
+
+    return(myens)
+

--- a/climaf/standard_operators.py
+++ b/climaf/standard_operators.py
@@ -328,6 +328,11 @@ def load_standard_operators():
             _var='curltau')
 
     #
+    # rmse_xyt
+    cscript(
+        'rmse_xyt', 'cdo sqrt -fldmean -timmean -sqr -sub ${in_1} ${in_2} ${out}')
+    #
+
     if os.system("type cdfmean >/dev/null 2>&1") == 0:
         load_cdftools_operators()
     else:
@@ -465,6 +470,3 @@ def load_cdftools_operators():
             'zo${Var}_${basin} tmpfile.nc ${out}; rm -f tmpfile.nc zonalmean.nc',
             _var="zo%s_${basin}", canSelectVar=True)
     #
-    # rmse_xyt
-    cscript(
-        'rmse_xyt', 'cdo sqrt -fldmean -timmean -sqr -sub ${in_1} ${in_2} ${out}')


### PR DESCRIPTION
Added two functions to save a CliMAF ensemble object as a json file and load it back to CliMAF as a ready-to-use ensemble object.